### PR TITLE
feat: add git hooks with pre-commit framework

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,68 @@
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v1.3.0
+      # https://github.com/pre-commit/pre-commit-hooks/blob/master/README.md
+      hooks:
+      - id: check-added-large-files     # Prevent giant files from being committed.
+        stages: [commit, push]
+      - id: check-ast                   # Simply check whether files parse as valid python.
+        stages: [commit, push]
+      - id: check-byte-order-marker     # Forbid files which have a UTF-8 byte-order marker
+        stages: [commit, push]
+      - id: check-docstring-first       # Checks for a common error of placing code before the docstring.
+        stages: [commit, push]
+      - id: check-executables-have-shebangs # Checks that non-binary executables have a proper shebang.
+        stages: [commit, push]
+      - id: check-json                  # Attempts to load all json files to verify syntax.
+        stages: [commit, push]
+      - id: check-merge-conflict        # Check for files that contain merge conflict strings.
+        stages: [commit, push]
+      - id: check-symlinks              # Checks for symlinks which do not point to anything.
+        stages: [commit, push]
+      - id: check-vcs-permalinks        # Ensures that links to vcs websites are permalinks.
+        stages: [commit, push]
+      - id: check-xml                   # Attempts to load all xml files to verify syntax.
+        stages: [commit, push]
+      - id: check-yaml                  # Attempts to load all yaml files to verify syntax.
+        stages: [commit, push]
+      - id: debug-statements            # Check for debugger imports and py37+ breakpoint() calls in python source.
+        stages: [commit, push]
+      - id: detect-private-key          # Checks for the existence of private keys.
+        stages: [commit, push]
+      - id: end-of-file-fixer           # Makes sure files end in a newline and only a newline.
+        stages: [commit, push]
+      - id: flake8                      # Run flake8 on your python files.
+        stages: [commit, push]
+      - id: forbid-new-submodules       # Prevent addition of new git submodules.
+        stages: [commit, push]
+      - id: mixed-line-ending           # Replaces or checks mixed line ending.
+        stages: [commit, push]
+      - id: pretty-format-json          # Checks that all your JSON files have keys that are sorted and indented.
+        stages: [commit, push]
+      - id: trailing-whitespace         # Trims trailing whitespace.
+        stages: [commit, push]
+
+    - repo: https://github.com/python/black
+      rev: stable
+      hooks:
+      - id: black
+        stages: [commit, push]
+        language_version: python3.7
+        args: [--check]
+
+    - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+      rev: v1.0.0
+      hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional']
+
+    - repo: local
+      hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        stages: [commit, push]
+        args: [-j 0]                    # Uses multiple processes to speed up pylint


### PR DESCRIPTION
This commit adds the pre-commit configuration file. Contributors
still have to manually install pre-commit and run the following:
```
pre-commit install -t pre-commit
pre-commit install -t pre-push
pre-commit install -t commit-msg
```
This will create hooks for the corresponding phases under `.git/hooks/`.
A few notes on some style and linting choices made here:
* `black` is a python code formatter. However, the hooks will only use
it to check if the code abides by its code style
* `commitlint` will check if the commit message abides by the [conventional
commits format](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
* `pylint` is a python code linter (duh). Its behaviour can be customized
by creating and editing a `pylintrc` file

Signed-off-by: Ângelo Lovatto <angelolovatto@gmail.com>