### PR TITLE
test: add pytest unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+dist: xenial   # required for Python >= 3.7
+language: python
+python:
+  - "3.7"
+  # PyPy versions
+  - "pypy3.5"
+# command to install dependencies
+install:
+  - pip install .
+# command to run tests
+script: pytest

--- a/mapo/tests/__init__.py
+++ b/mapo/tests/__init__.py
@@ -1,0 +1,1 @@
+# pylint: disable=missing-docstring

--- a/mapo/tests/mock_env.py
+++ b/mapo/tests/mock_env.py
@@ -1,0 +1,23 @@
+"""Dummy gym.Env subclasses."""
+import gym
+from gym.spaces import Box
+import numpy as np
+
+
+class MockEnv(gym.Env):  # pylint: disable=abstract-method
+    """Dummy environment with continuous action space."""
+
+    def __init__(self, config=None):
+        self.config = config
+        self.horizon = 200
+        self.time = 0
+        self.observation_space = Box(high=1, low=-1, shape=(4,), dtype=np.float32)
+        self.action_space = Box(high=1, low=-1, shape=(2,), dtype=np.float32)
+
+    def reset(self):
+        self.time = 0
+        return self.observation_space.sample()
+
+    def step(self, action):
+        self.time += 1
+        return self.observation_space.sample(), 1, self.time >= self.horizon, {}

--- a/mapo/tests/test_checkpoint.py
+++ b/mapo/tests/test_checkpoint.py
@@ -1,0 +1,27 @@
+"""Tests for agent saving and loading."""
+import numpy as np
+import ray
+from ray.tune import register_env
+from mapo.tests.mock_env import MockEnv
+from mapo.agents.mapo import MAPOTrainer
+
+
+def test_checkpoint_restore(tmpdir):
+    """
+    Check if agents can be succesfully restored.
+
+    Assumes the result of `compute_action` is deterministic for a given observation.
+    """
+    ray.init()
+    register_env("test", lambda _: MockEnv())
+    agent1 = MAPOTrainer(env="test")
+    agent2 = MAPOTrainer(env="test")
+
+    for _ in range(3):
+        agent1.train()
+    agent2.restore(agent1.save(tmpdir))
+
+    env = MockEnv()
+    obs = env.observation_space.sample()
+    action1, action2 = agent1.compute_action(obs), agent2.compute_action(obs)
+    assert np.allclose(action1, action2)

--- a/mapo/tests/test_rollout.py
+++ b/mapo/tests/test_rollout.py
@@ -1,0 +1,15 @@
+"""Tests for agent-environment interface."""
+from mapo.tests.mock_env import MockEnv
+from mapo.agents.mapo.mapo_policy import MAPOTFPolicy
+
+
+def test_compute_single_action():
+    """Test if policy returns single action from the correct space."""
+    env = MockEnv()
+    policy = MAPOTFPolicy(env.observation_space, env.action_space, {})
+
+    obs = env.reset()
+    # the list is a placeholder for RNN state inputs
+    action, _, _ = policy.compute_single_action(obs, [])
+
+    assert action in env.action_space

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:tensorflow:
+    ignore::DeprecationWarning:google:
+    ignore::DeprecationWarning:flatbuffers:


### PR DESCRIPTION
Opted for having tests as part of the application code, also done in `rllib`:
https://docs.pytest.org/en/latest/goodpractices.html#tests-as-part-of-application-code
https://github.com/ray-project/ray/tree/master/python/ray/rllib

Since `ray` is in the package requirements, `pytest` is already installed:
https://github.com/ray-project/ray/blob/master/python/setup.py#L138

Created a `pytest.ini` file. The initial configuration is set to ignore
deprecation warnings from some third-party packages.

Closes #21 