### PR TITLE
Add separate optimizers and delayed updates

### DIFF
--- a/mapo/agents/mapo/mapo.py
+++ b/mapo/agents/mapo/mapo.py
@@ -20,6 +20,13 @@ DEFAULT_CONFIG = with_common_config(
         "critic_hiddens": [64, 64],
         # Hidden layers activation of the critic.
         "critic_hidden_activation": "relu",
+        # === Optimization ===
+        # Learning rate for the critic (Q-function) optimizer.
+        "critic_lr": 1e-3,
+        # Learning rate for the actor (policy) optimizer.
+        "actor_lr": 1e-3,
+        # delayed policy update
+        "policy_delay": 1,
         # === Resources ===
         # Number of actors used for parallelism
         "num_workers": 0,

--- a/mapo/agents/mapo/mapo.py
+++ b/mapo/agents/mapo/mapo.py
@@ -12,31 +12,17 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 DEFAULT_CONFIG = with_common_config(
     {
         # === Model ===
-        # Apply a state preprocessor with spec given by the "model" config option
-        # (like other RL algorithms). This is mostly useful if you have a weird
-        # observation shape, like an image. Disabled by default.
-        "use_state_preprocessor": False,
-        # Postprocess the policy network model output with these hidden layers. If
-        # use_state_preprocessor is False, then these will be the *only* hidden
-        # layers in the network.
+        # Process the observation input tensors with these hidden layers.
         "actor_hiddens": [64, 64],
-        # Hidden layers activation of the postprocessing stage of the policy
-        # network
+        # Hidden layers activation of the policy network
         "actor_hidden_activation": "relu",
-        # Postprocess the critic network model output with these hidden layers;
-        # again, if use_state_preprocessor is True, then the state will be
-        # preprocessed by the model specified with the "model" config option first.
+        # Process the observation and action input tensors with these hidden layers.
         "critic_hiddens": [64, 64],
-        # Hidden layers activation of the postprocessing state of the critic.
+        # Hidden layers activation of the critic.
         "critic_hidden_activation": "relu",
         # === Resources ===
         # Number of actors used for parallelism
         "num_workers": 0,
-        # === Optimization ===
-        # Learning rate for the critic (Q-function) optimizer.
-        "critic_lr": 1e-3,
-        # Learning rate for the actor (policy) optimizer.
-        "actor_lr": 1e-3,
     }
 )
 

--- a/mapo/agents/mapo/mapo_policy.py
+++ b/mapo/agents/mapo/mapo_policy.py
@@ -3,16 +3,11 @@ import tensorflow as tf
 from tensorflow import keras
 from gym.spaces import Box
 
-from ray.rllib.policy import build_tf_policy
+from ray.rllib.policy import build_tf_policy, TFPolicy
 from ray.rllib.utils.error import UnsupportedSpaceException
+from ray.rllib.utils.annotations import override
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.evaluation.postprocessing import compute_advantages, Postprocessing
-
-
-def postprocess_returns(policy, sample_batch, other_agent_batches=None, episode=None):
-    # pylint: disable=unused-argument
-    """Add trajectory returns."""
-    return compute_advantages(sample_batch, 0.0, policy.config["gamma"], use_gae=False)
 
 
 def build_actor_critic_losses(policy, batch_tensors):
@@ -23,18 +18,47 @@ def build_actor_critic_losses(policy, batch_tensors):
         batch_tensors[SampleBatch.ACTIONS],
         batch_tensors[Postprocessing.ADVANTAGES],
     )
-    q_function, policy = policy.q_function, policy.policy
+    q_model, policy_model = policy.q_function, policy.policy
 
-    critic_loss = keras.losses.mean_squared_error(q_function([obs, actions]), returns)
+    policy.critic_loss = keras.losses.mean_squared_error(
+        q_model([obs, actions]), returns
+    )
     # DPG loss
-    actor_loss = -tf.reduce_mean(q_function([obs, policy(obs)]))
+    policy.actor_loss = -tf.reduce_mean(q_model([obs, policy_model(obs)]))
+    return policy.actor_loss + policy.critic_loss
 
-    return actor_loss + critic_loss
+
+def get_default_config():
+    """Get the default configuration for MAPOTFPolicy."""
+    from mapo.agents.mapo.mapo import DEFAULT_CONFIG  # pylint: disable=cyclic-import
+
+    return DEFAULT_CONFIG
+
+
+def postprocess_returns(policy, sample_batch, other_agent_batches=None, episode=None):
+    """Add trajectory returns."""
+    # pylint: disable=unused-argument
+    return compute_advantages(sample_batch, 0.0, policy.config["gamma"], use_gae=False)
+
+
+def actor_critic_gradients(policy, *_):
+    """Create compute gradients ops using separate optimizers."""
+    # pylint: disable=protected-access
+    actor_grads = policy._actor_optimizer.get_gradients(
+        policy.actor_loss, policy.policy.variables
+    )
+    critic_grads = policy._critic_optimizer.get_gradients(
+        policy.critic_loss, policy.q_function.variables
+    )
+    # Save these for later use in build_apply_op
+    policy._actor_grads_and_vars = list(zip(actor_grads, policy.policy.variables))
+    policy._critic_grads_and_vars = list(zip(critic_grads, policy.q_function.variables))
+    return policy._actor_grads_and_vars + policy._critic_grads_and_vars
 
 
 def check_action_space(policy, obs_space, action_space, config):
-    # pylint: disable=unused-argument
     """Check if the action space is suited to DPG."""
+    # pylint: disable=unused-argument
     if not isinstance(action_space, Box):
         raise UnsupportedSpaceException(
             "Action space {} is not supported for MAPO.".format(action_space)
@@ -45,6 +69,14 @@ def check_action_space(policy, obs_space, action_space, config):
             + "Consider reshaping this into a single dimension, using a Tuple action"
             "space, or the multi-agent API."
         )
+
+
+def create_separate_optimizers(policy, obs_space, action_space, config):
+    """Initialize optimizers and global step for update operations."""
+    # pylint: disable=unused-argument,protected-access
+    policy._actor_optimizer = keras.optimizers.Adam(learning_rate=config["actor_lr"])
+    policy._critic_optimizer = keras.optimizers.Adam(learning_rate=config["critic_lr"])
+    policy.global_step = tf.Variable(0, trainable=False)
 
 
 def build_continuous_q_function(obs_space, action_space, config):
@@ -99,11 +131,36 @@ def build_actor_critic_models(policy, input_dict, obs_space, action_space, confi
     return actions, None
 
 
-def get_default_config():
-    """Get the default configuration for MAPOTFPolicy."""
-    from mapo.agents.mapo.mapo import DEFAULT_CONFIG  # pylint: disable=cyclic-import
+class DelayedUpdatesMixin:  # pylint: disable=too-few-public-methods
+    """
+    Sets ops to update models with different frequencies.
 
-    return DEFAULT_CONFIG
+    This mixin is needed since `build_tf_policy` does not have an argument to
+    override `TFPolicy.build_apply_op`.
+    """
+
+    @override(TFPolicy)
+    def build_apply_op(self, *_):
+        """
+        Update actor and critic models with different frequencies.
+
+        For policy gradient, update policy net one time v.s. update critic net
+        `policy_delay` time(s).
+        """
+        should_apply_actor_opt = tf.equal(
+            tf.math.mod(self.global_step, self.config["policy_delay"]), 0
+        )
+
+        def make_apply_op():
+            return self._actor_optimizer.apply_gradients(self._actor_grads_and_vars)
+
+        actor_op = tf.cond(
+            should_apply_actor_opt, true_fn=make_apply_op, false_fn=tf.no_op
+        )
+        critic_op = self._critic_optimizer.apply_gradients(self._critic_grads_and_vars)
+        # increment global step & apply ops
+        with tf.control_dependencies([self.global_step.assign_add(1)]):
+            return tf.group(actor_op, critic_op)
 
 
 MAPOTFPolicy = build_tf_policy(
@@ -111,6 +168,10 @@ MAPOTFPolicy = build_tf_policy(
     loss_fn=build_actor_critic_losses,
     get_default_config=get_default_config,
     postprocess_fn=postprocess_returns,
+    optimizer_fn=lambda *_: None,
+    gradients_fn=actor_critic_gradients,
     before_init=check_action_space,
+    before_loss_init=create_separate_optimizers,
     make_action_sampler=build_actor_critic_models,
+    mixins=[DelayedUpdatesMixin],
 )


### PR DESCRIPTION
Created models for actor and critic using the keras functional API (still no specific classes for each).

Added separate optimizers for actor and critic (should be straightforward to extend when we add the predictive model).

Now supports delayed updates for the actor. Again, should be easy to generalize to the MBRL case. Here's some code to verify that it's actually working:
```python
import ray
from mapo.agents.mapo import MAPOTrainer
ray.init()
agent1 = MAPOTrainer(env="Pendulum-v0", config={"log_level": "WARN", "policy_delay": 2})

for _ in range(6):
    agent1.train()

policy = agent1.get_policy()
actor_optim, critic_optim = policy._actor_optimizer, policy._critic_optimizer
sess = policy.get_session()
sess.run(actor_optim.iterations) # should be 3
```