### PR TITLE
Feature/off policy learning

### DIFF
--- a/mapo/agents/mapo/mapo.py
+++ b/mapo/agents/mapo/mapo.py
@@ -5,8 +5,6 @@ import logging
 from ray.rllib.agents.trainer import with_common_config
 from ray.rllib.agents.trainer_template import build_trainer
 from mapo.agents.mapo.mapo_policy import MAPOTFPolicy
-from mapo.models.q_function import DEFAULT_CONFIG as ACTOR_MODEL_CONFIG
-from mapo.models.policy import DEFAULT_CONFIG as CRITIC_MODEL_CONFIG
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -14,8 +12,8 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 DEFAULT_CONFIG = with_common_config(
     {
         # === Model ===
-        "actor_model": ACTOR_MODEL_CONFIG,
-        "critic_model": CRITIC_MODEL_CONFIG,
+        "actor_model": {},
+        "critic_model": {},
         # === Optimization ===
         # Learning rate for the critic (Q-function) optimizer.
         "critic_lr": 1e-3,

--- a/mapo/agents/off_mapo/__init__.py
+++ b/mapo/agents/off_mapo/__init__.py
@@ -1,0 +1,4 @@
+# pylint: disable=missing-docstring
+from mapo.agents.off_mapo.off_mapo import OffMAPOTrainer, DEFAULT_CONFIG
+
+__all__ = ["OffMAPOTrainer", "DEFAULT_CONFIG"]

--- a/mapo/agents/off_mapo/off_mapo.py
+++ b/mapo/agents/off_mapo/off_mapo.py
@@ -6,6 +6,8 @@ from ray.rllib.agents.trainer import with_common_config
 from ray.rllib.agents.trainer_template import build_trainer
 from ray.rllib.optimizers import SyncReplayOptimizer
 from mapo.agents.off_mapo.off_mapo_policy import OffMAPOTFPolicy
+from mapo.models.policy import DEFAULT_CONFIG as ACTOR_MODEL_CONFIG
+from mapo.models.q_function import DEFAULT_CONFIG as CRITIC_MODEL_CONFIG
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -15,14 +17,10 @@ DEFAULT_CONFIG = with_common_config(
         # === Model ===
         # twin Q-net
         "twin_q": True,
-        # Process the observation input tensors with these hidden layers.
-        "actor_hiddens": [400, 300],
-        # Hidden layers activation of the policy network
-        "actor_hidden_activation": "relu",
-        # Process the observation and action input tensors with these hidden layers.
-        "critic_hiddens": [400, 300],
-        # Hidden layers activation of the critic.
-        "critic_hidden_activation": "relu",
+        # policy network configuration
+        "actor_model": ACTOR_MODEL_CONFIG,
+        # Q function network configuration
+        "critic_model": CRITIC_MODEL_CONFIG,
         # === Exploration ===
         # valid values: "ou" (time-correlated, like original DDPG paper),
         # "gaussian" (IID, like TD3 paper)

--- a/mapo/agents/off_mapo/off_mapo.py
+++ b/mapo/agents/off_mapo/off_mapo.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 DEFAULT_CONFIG = with_common_config(
     {
         # === Model ===
+        # twin Q-net
+        "twin_q": True,
         # Process the observation input tensors with these hidden layers.
         "actor_hiddens": [400, 300],
         # Hidden layers activation of the policy network

--- a/mapo/agents/off_mapo/off_mapo.py
+++ b/mapo/agents/off_mapo/off_mapo.py
@@ -1,0 +1,73 @@
+"""Driver for off-policy variant of MAPO."""
+
+import logging
+
+from ray.rllib.agents.trainer import with_common_config
+from ray.rllib.agents.trainer_template import build_trainer
+from ray.rllib.optimizers import SyncReplayOptimizer
+from mapo.agents.off_mapo.off_mapo_policy import OffMAPOTFPolicy
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+DEFAULT_CONFIG = with_common_config(
+    {
+        # === Model ===
+        # Process the observation input tensors with these hidden layers.
+        "actor_hiddens": [400, 300],
+        # Hidden layers activation of the policy network
+        "actor_hidden_activation": "relu",
+        # Process the observation and action input tensors with these hidden layers.
+        "critic_hiddens": [400, 300],
+        # Hidden layers activation of the critic.
+        "critic_hidden_activation": "relu",
+        # === Optimization ===
+        # Learning rate for the critic (Q-function) optimizer.
+        "critic_lr": 1e-3,
+        # Learning rate for the actor (policy) optimizer.
+        "actor_lr": 1e-3,
+        # Update the target network every `target_network_update_freq` steps.
+        "target_network_update_freq": 0,
+        # Update the target by \tau * policy + (1-\tau) * target_policy
+        "tau": 0.005,
+        # delayed policy update
+        "policy_delay": 2,
+        # How many environment steps to take before learning starts.
+        "learning_starts": 1500,
+        # === Resources ===
+        # Number of actors used for parallelism
+        "num_workers": 0,
+        # === Replay buffer ===
+        # Size of the replay buffer. Note that if async_updates is set, then
+        # each worker will have a replay buffer of this size.
+        "buffer_size": int(1e6),
+        # === Execution ===
+        # Update the replay buffer with this many samples at once. Note that this
+        # setting applies per-worker if num_workers > 1.
+        "sample_batch_size": 1,
+        # Size of a batched sampled from replay buffer for training. Note that
+        # if async_updates is set, then each worker returns gradients for a
+        # batch of this size.
+        "train_batch_size": 100,
+    }
+)
+
+
+def make_policy_optimizer(worker_set, config):
+    """Create SyncReplayOptimizer."""
+    return SyncReplayOptimizer(
+        worker_set,
+        learning_starts=config["learning_starts"],
+        buffer_size=config["buffer_size"],
+        prioritized_replay=False,
+        train_batch_size=config["train_batch_size"],
+        sample_batch_size=config["sample_batch_size"],
+    )
+
+
+OffMAPOTrainer = build_trainer(
+    name="OffMAPO",
+    default_policy=OffMAPOTFPolicy,
+    default_config=DEFAULT_CONFIG,
+    make_policy_optimizer=make_policy_optimizer,
+)

--- a/mapo/agents/off_mapo/off_mapo.py
+++ b/mapo/agents/off_mapo/off_mapo.py
@@ -23,6 +23,26 @@ DEFAULT_CONFIG = with_common_config(
         "critic_hiddens": [400, 300],
         # Hidden layers activation of the critic.
         "critic_hidden_activation": "relu",
+        # === Exploration ===
+        # valid values: "ou" (time-correlated, like original DDPG paper),
+        # "gaussian" (IID, like TD3 paper)
+        "exploration_noise_type": "gaussian",
+        # OU-noise scale; this can be used to scale down magnitude of OU noise
+        # before adding to actions (requires "exploration_noise_type" to be "ou")
+        "exploration_ou_noise_scale": 0.1,
+        # theta for OU
+        "exploration_ou_theta": 0.15,
+        # sigma for OU
+        "exploration_ou_sigma": 0.2,
+        # gaussian stddev of act noise for exploration (requires
+        # "exploration_noise_type" to be "gaussian")
+        "exploration_gaussian_sigma": 0.1,
+        # Until this many timesteps have elapsed, the agent's policy will be
+        # ignored & it will instead take uniform random actions. Can be used in
+        # conjunction with learning_starts (which controls when the first
+        # optimization step happens) to decrease dependence of exploration &
+        # optimization on initial policy parameters.
+        "pure_exploration_steps": 1000,
         # === Optimization ===
         # Learning rate for the critic (Q-function) optimizer.
         "critic_lr": 1e-3,
@@ -39,7 +59,7 @@ DEFAULT_CONFIG = with_common_config(
         # delayed policy update
         "policy_delay": 2,
         # How many environment steps to take before learning starts.
-        "learning_starts": 1500,
+        "learning_starts": 0,
         # === Resources ===
         # Number of actors used for parallelism
         "num_workers": 0,
@@ -55,6 +75,22 @@ DEFAULT_CONFIG = with_common_config(
         # if async_updates is set, then each worker returns gradients for a
         # batch of this size.
         "train_batch_size": 100,
+        # Number of env steps to optimize for before returning
+        "timesteps_per_iteration": 1000,
+        # === Evaluation ===
+        # Evaluate with every `evaluation_interval` training iterations.
+        # The evaluation stats will be reported under the "evaluation" metric key.
+        # Note that evaluation is currently not parallelized, and that for Ape-X
+        # metrics are already only reported for the lowest epsilon workers.
+        "evaluation_interval": None,
+        # Number of episodes to run per evaluation period.
+        "evaluation_num_episodes": 10,
+        # Extra arguments to pass to evaluation workers.
+        # Typical usage is to pass extra args to evaluation env creator
+        # and to disable exploration by computing deterministic actions
+        "evaluation_config": {"evaluate": True},
+        # Turn of exploration noise when evaluating the policy
+        "evaluate": False,
     }
 )
 
@@ -71,9 +107,28 @@ def make_policy_optimizer(worker_set, config):
     )
 
 
+def add_pure_exploration_phase(trainer):
+    """
+    Set all policies to pure exploration until `pure_exploration_steps` have elapsed.
+    """
+    global_timestep = trainer.optimizer.num_steps_sampled
+    pure_expl_steps = trainer.config["pure_exploration_steps"]
+    if pure_expl_steps:
+        # tell workers whether they should do pure exploration
+        only_explore = global_timestep < pure_expl_steps
+        trainer.workers.local_worker().foreach_trainable_policy(
+            lambda p, _: p.set_pure_exploration_phase(only_explore)
+        )
+        for worker in trainer.workers.remote_workers():
+            worker.foreach_trainable_policy.remote(
+                lambda p, _: p.set_pure_exploration_phase(only_explore)
+            )
+
+
 OffMAPOTrainer = build_trainer(
     name="OffMAPO",
     default_policy=OffMAPOTFPolicy,
     default_config=DEFAULT_CONFIG,
     make_policy_optimizer=make_policy_optimizer,
+    before_train_step=add_pure_exploration_phase,
 )

--- a/mapo/agents/off_mapo/off_mapo.py
+++ b/mapo/agents/off_mapo/off_mapo.py
@@ -6,8 +6,6 @@ from ray.rllib.agents.trainer import with_common_config
 from ray.rllib.agents.trainer_template import build_trainer
 from ray.rllib.optimizers import SyncReplayOptimizer
 from mapo.agents.off_mapo.off_mapo_policy import OffMAPOTFPolicy
-from mapo.models.policy import DEFAULT_CONFIG as ACTOR_MODEL_CONFIG
-from mapo.models.q_function import DEFAULT_CONFIG as CRITIC_MODEL_CONFIG
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -18,9 +16,9 @@ DEFAULT_CONFIG = with_common_config(
         # twin Q-net
         "twin_q": True,
         # policy network configuration
-        "actor_model": ACTOR_MODEL_CONFIG,
+        "actor_model": {},
         # Q function network configuration
-        "critic_model": CRITIC_MODEL_CONFIG,
+        "critic_model": {},
         # === Exploration ===
         # valid values: "ou" (time-correlated, like original DDPG paper),
         # "gaussian" (IID, like TD3 paper)

--- a/mapo/agents/off_mapo/off_mapo.py
+++ b/mapo/agents/off_mapo/off_mapo.py
@@ -30,6 +30,12 @@ DEFAULT_CONFIG = with_common_config(
         "actor_lr": 1e-3,
         # Update the target by \tau * policy + (1-\tau) * target_policy
         "tau": 0.005,
+        # target policy smoothing
+        "smooth_target_policy": True,
+        # gaussian stddev of target action noise for smoothing
+        "target_noise": 0.2,
+        # target noise limit (bound)
+        "target_noise_clip": 0.5,
         # delayed policy update
         "policy_delay": 2,
         # How many environment steps to take before learning starts.

--- a/mapo/agents/off_mapo/off_mapo.py
+++ b/mapo/agents/off_mapo/off_mapo.py
@@ -26,8 +26,6 @@ DEFAULT_CONFIG = with_common_config(
         "critic_lr": 1e-3,
         # Learning rate for the actor (policy) optimizer.
         "actor_lr": 1e-3,
-        # Update the target network every `target_network_update_freq` steps.
-        "target_network_update_freq": 0,
         # Update the target by \tau * policy + (1-\tau) * target_policy
         "tau": 0.005,
         # delayed policy update

--- a/mapo/agents/off_mapo/off_mapo_policy.py
+++ b/mapo/agents/off_mapo/off_mapo_policy.py
@@ -21,6 +21,21 @@ def _build_critic_targets(policy, batch_tensors):
     gamma = policy.config["gamma"]
     target_q_model = policy.target_q_model
     next_action = policy.target_policy_model(next_obs)
+    if policy.config["smooth_target_policy"]:
+        epsilon = tf.random.normal(
+            tf.shape(next_action), stddev=policy.config["target_noise"]
+        )
+        epsilon = tf.clip_by_value(
+            epsilon,
+            -policy.config["target_noise_clip"],
+            policy.config["target_noise_clip"],
+        )
+        next_action = next_action + epsilon
+        next_action = tf.clip_by_value(
+            next_action,
+            tf.constant(policy.action_space.low),
+            tf.constant(policy.action_space.high),
+        )
     next_q_values = target_q_model([next_obs, next_action])
     if policy.config["twin_q"]:
         target_twin_q_model = policy.target_twin_q_model

--- a/mapo/agents/off_mapo/off_mapo_policy.py
+++ b/mapo/agents/off_mapo/off_mapo_policy.py
@@ -1,0 +1,138 @@
+"""MAPOTFPolicy with DDPG and TD3 tricks."""
+import tensorflow as tf
+from tensorflow import keras
+from gym.spaces import Box
+
+from ray.rllib.policy import build_tf_policy, TFPolicy
+from ray.rllib.utils.error import UnsupportedSpaceException
+from ray.rllib.utils.annotations import override
+from ray.rllib.policy.sample_batch import SampleBatch
+
+from mapo.models.policy import build_deterministic_policy
+from mapo.models.q_function import build_continuous_q_function
+
+
+def build_actor_critic_losses(policy, batch_tensors):
+    """Contruct actor (DPG) and critic (Fitted Q) losses."""
+    obs, actions, rewards, dones, next_obs = (
+        batch_tensors[SampleBatch.CUR_OBS],
+        batch_tensors[SampleBatch.ACTIONS],
+        batch_tensors[SampleBatch.REWARDS],
+        batch_tensors[SampleBatch.DONES],
+        batch_tensors[SampleBatch.NEXT_OBS],
+    )
+    q_model, policy_model = policy.q_model, policy.policy_model
+
+    gamma = policy.config["gamma"]
+    # Do not bootstrap if the state is terminal
+    bootstrapped = tf.squeeze(
+        rewards + gamma * q_model([next_obs, policy_model(next_obs)])
+    )
+    q_targets = tf.compat.v1.where(dones, x=rewards, y=bootstrapped)
+    policy.critic_loss = keras.losses.mean_squared_error(
+        q_model([obs, actions]), q_targets
+    )
+    # DPG loss
+    policy.actor_loss = -tf.reduce_mean(q_model([obs, policy_model(obs)]))
+    return policy.actor_loss + policy.critic_loss
+
+
+def get_default_config():
+    """Get the default configuration for OffMAPOTFPolicy."""
+    # pylint: disable=cyclic-import
+    from mapo.agents.off_mapo.off_mapo import DEFAULT_CONFIG
+
+    return DEFAULT_CONFIG
+
+
+def actor_critic_gradients(policy, *_):
+    """Create compute gradients ops using separate optimizers."""
+    # pylint: disable=protected-access
+    actor_grads = policy._actor_optimizer.get_gradients(
+        policy.actor_loss, policy.policy_model.variables
+    )
+    critic_grads = policy._critic_optimizer.get_gradients(
+        policy.critic_loss, policy.q_model.variables
+    )
+    # Save these for later use in build_apply_op
+    policy._actor_grads_and_vars = list(zip(actor_grads, policy.policy_model.variables))
+    policy._critic_grads_and_vars = list(zip(critic_grads, policy.q_model.variables))
+    return policy._actor_grads_and_vars + policy._critic_grads_and_vars
+
+
+def check_action_space(policy, obs_space, action_space, config):
+    """Check if the action space is suited to DPG."""
+    # pylint: disable=unused-argument
+    if not isinstance(action_space, Box):
+        raise UnsupportedSpaceException(
+            "Action space {} is not supported for MAPO.".format(action_space)
+        )
+    if len(action_space.shape) > 1:
+        raise UnsupportedSpaceException(
+            "Action space has multiple dimensions {}.".format(action_space.shape)
+            + "Consider reshaping this into a single dimension, using a Tuple action"
+            "space, or the multi-agent API."
+        )
+
+
+def create_separate_optimizers(policy, obs_space, action_space, config):
+    """Initialize optimizers and global step for update operations."""
+    # pylint: disable=unused-argument,protected-access
+    policy._actor_optimizer = keras.optimizers.Adam(learning_rate=config["actor_lr"])
+    policy._critic_optimizer = keras.optimizers.Adam(learning_rate=config["critic_lr"])
+    policy.global_step = tf.Variable(0, trainable=False)
+
+
+def build_actor_critic_models(policy, input_dict, obs_space, action_space, config):
+    """Construct actor and critic keras models, and return actor action tensor."""
+    policy.q_model = build_continuous_q_function(obs_space, action_space, config)
+    policy.policy_model = build_deterministic_policy(obs_space, action_space, config)
+
+    actions = policy.policy_model(input_dict[SampleBatch.CUR_OBS])
+    return actions, None
+
+
+class DelayedUpdatesMixin:  # pylint: disable=too-few-public-methods
+    """
+    Sets ops to update models with different frequencies.
+
+    This mixin is needed since `build_tf_policy` does not have an argument to
+    override `TFPolicy.build_apply_op`.
+    """
+
+    @override(TFPolicy)
+    def build_apply_op(self, *_):
+        """
+        Update actor and critic models with different frequencies.
+
+        For policy gradient, update policy net one time v.s. update critic net
+        `policy_delay` time(s).
+        """
+        should_apply_actor_opt = tf.equal(
+            tf.math.mod(self.global_step, self.config["policy_delay"]), 0
+        )
+
+        def make_apply_op():
+            return self._actor_optimizer.apply_gradients(self._actor_grads_and_vars)
+
+        actor_op = tf.cond(
+            should_apply_actor_opt, true_fn=make_apply_op, false_fn=tf.no_op
+        )
+        critic_op = self._critic_optimizer.apply_gradients(self._critic_grads_and_vars)
+        # increment global step & apply ops
+        with tf.control_dependencies([self.global_step.assign_add(1)]):
+            return tf.group(actor_op, critic_op)
+
+
+OffMAPOTFPolicy = build_tf_policy(
+    name="OffMAPOTFPolicy",
+    loss_fn=build_actor_critic_losses,
+    get_default_config=get_default_config,
+    optimizer_fn=lambda *_: None,
+    gradients_fn=actor_critic_gradients,
+    before_init=check_action_space,
+    before_loss_init=create_separate_optimizers,
+    make_action_sampler=build_actor_critic_models,
+    mixins=[DelayedUpdatesMixin],
+    obs_include_prev_action_reward=False,
+)

--- a/mapo/agents/off_mapo/off_mapo_policy.py
+++ b/mapo/agents/off_mapo/off_mapo_policy.py
@@ -44,7 +44,7 @@ def _build_critic_targets(policy, batch_tensors):
         )
     bootstrapped = rewards + gamma * tf.squeeze(next_q_values)
     # Do not bootstrap if the state is terminal
-    return tf.compat.v1.where(dones, x=rewards, y=bootstrapped)
+    return tf.compat.v2.where(dones, x=rewards, y=bootstrapped)
 
 
 def _build_critic_loss(policy, batch_tensors):

--- a/mapo/agents/off_mapo/off_mapo_policy.py
+++ b/mapo/agents/off_mapo/off_mapo_policy.py
@@ -34,14 +34,14 @@ def _build_critic_targets(policy, batch_tensors):
         next_action = tf.clip_by_value(
             next_action, policy.action_space.low, policy.action_space.high
         )
-    next_q_values = target_q_model([next_obs, next_action])
+    next_q_values = tf.squeeze(target_q_model([next_obs, next_action]))
     if policy.config["twin_q"]:
         target_twin_q_model = policy.target_twin_q_model
         next_q_values = tf.math.minimum(
-            next_q_values, target_twin_q_model([next_obs, next_action])
+            next_q_values, tf.squeeze(target_twin_q_model([next_obs, next_action]))
         )
-    bootstrapped = rewards + gamma * tf.squeeze(next_q_values)
     # Do not bootstrap if the state is terminal
+    bootstrapped = rewards + gamma * next_q_values
     return tf.compat.v2.where(dones, x=rewards, y=bootstrapped)
 
 
@@ -52,7 +52,7 @@ def _build_critic_loss(policy, batch_tensors):
     )
     target_q_values = _build_critic_targets(policy, batch_tensors)
     q_loss_criterion = keras.losses.MeanSquaredError()
-    q_pred = policy.q_model([obs, actions])
+    q_pred = tf.squeeze(policy.q_model([obs, actions]))
     q_stats = {
         "q_mean": tf.reduce_mean(q_pred),
         "q_max": tf.reduce_max(q_pred),
@@ -61,7 +61,7 @@ def _build_critic_loss(policy, batch_tensors):
     policy.loss_stats.update(q_stats)
     critic_loss = q_loss_criterion(q_pred, target_q_values)
     if policy.config["twin_q"]:
-        twin_q_pred = policy.twin_q_model([obs, actions])
+        twin_q_pred = tf.squeeze(policy.twin_q_model([obs, actions]))
         twin_q_stats = {
             "twin_q_mean": tf.reduce_mean(twin_q_pred),
             "twin_q_max": tf.reduce_max(twin_q_pred),

--- a/mapo/agents/off_mapo/off_mapo_policy.py
+++ b/mapo/agents/off_mapo/off_mapo_policy.py
@@ -135,10 +135,7 @@ def create_separate_optimizers(policy, obs_space, action_space, config):
 def copy_targets(policy, obs_space, action_space, config):
     """Copy parameters from original models to target models."""
     # pylint: disable=unused-argument
-    policy.target_init = tf.group(
-        policy.build_update_target_actor_op(tau=1),
-        policy.build_update_target_critic_op(tau=1),
-    )
+    policy.target_init = policy.build_update_targets_op(tau=1)
     policy.get_session().run(policy.target_init)
 
 
@@ -150,6 +147,10 @@ def build_actor_critic_models(policy, input_dict, obs_space, action_space, confi
     policy.target_policy_model = build_deterministic_policy(
         obs_space, action_space, config
     )
+    policy.main_variables = policy.q_model.variables + policy.policy_model.variables
+    policy.target_variables = (
+        policy.target_q_model.variables + policy.target_policy_model.variables
+    )
     if config["twin_q"]:
         policy.twin_q_model = build_continuous_q_function(
             obs_space, action_space, config
@@ -157,6 +158,8 @@ def build_actor_critic_models(policy, input_dict, obs_space, action_space, confi
         policy.target_twin_q_model = build_continuous_q_function(
             obs_space, action_space, config
         )
+        policy.main_variables += policy.twin_q_model.variables
+        policy.target_variables += policy.target_twin_q_model.variables
 
     actions = policy.policy_model(input_dict[SampleBatch.CUR_OBS])
     return actions, None
@@ -165,28 +168,15 @@ def build_actor_critic_models(policy, input_dict, obs_space, action_space, confi
 class TargetUpdatesMixin:
     """Adds methods to build ops that update target networks."""
 
-    def build_update_target_actor_op(self, tau=None):
-        """Build op to update target actor network."""
+    # pylint: disable=too-few-public-methods
+    def build_update_targets_op(self, tau=None):
+        """Build op to update target networks."""
         tau = tau or self.config["tau"]
-        actor_variables = self.policy_model.variables
-        target_actor_variables = self.target_policy_model.variables
+        main_variables = self.main_variables
+        target_variables = self.target_variables
         update_target_expr = [
             target_var.assign(tau * var + (1.0 - tau) * target_var)
-            for var, target_var in zip(actor_variables, target_actor_variables)
-        ]
-        return tf.group(*update_target_expr)
-
-    def build_update_target_critic_op(self, tau=None):
-        """Build op to update target critic network."""
-        tau = tau or self.config["tau"]
-        critic_variables = self.q_model.variables
-        target_critic_variables = self.target_q_model.variables
-        if self.config["twin_q"]:
-            critic_variables.extend(self.twin_q_model.variables)
-            target_critic_variables.extend(self.target_twin_q_model.variables)
-        update_target_expr = [
-            target_var.assign(tau * var + (1.0 - tau) * target_var)
-            for var, target_var in zip(critic_variables, target_critic_variables)
+            for var, target_var in zip(main_variables, target_variables)
         ]
         return tf.group(*update_target_expr)
 
@@ -205,7 +195,7 @@ class DelayedUpdatesMixin:  # pylint: disable=too-few-public-methods
         Update actor and critic models with different frequencies.
 
         For policy gradient, update policy net one time v.s. update critic net
-        `policy_delay` time(s).
+        `policy_delay` time(s). Also use `policy_delay` for target networks update.
         """
         # Actor updates
         should_apply_actor_opt = tf.equal(
@@ -215,19 +205,14 @@ class DelayedUpdatesMixin:  # pylint: disable=too-few-public-methods
         def make_actor_apply_op():
             app_grad = self._actor_optimizer.apply_gradients(self._actor_grads_and_vars)
             with tf.control_dependencies([app_grad]):
-                update_target_op = self.build_update_target_actor_op()
+                update_target_op = self.build_update_targets_op()
             return tf.group(app_grad, update_target_op)
 
         actor_op = tf.cond(
             should_apply_actor_opt, true_fn=make_actor_apply_op, false_fn=tf.no_op
         )
         # Critic updates
-        apply_critic_gradients = self._critic_optimizer.apply_gradients(
-            self._critic_grads_and_vars
-        )
-        with tf.control_dependencies([apply_critic_gradients]):
-            update_target_critic_op = self.build_update_target_critic_op()
-        critic_op = tf.group(apply_critic_gradients, update_target_critic_op)
+        critic_op = self._critic_optimizer.apply_gradients(self._critic_grads_and_vars)
         # increment global step & apply ops
         with tf.control_dependencies([self.global_step.assign_add(1)]):
             return tf.group(actor_op, critic_op)

--- a/mapo/agents/off_mapo/off_mapo_policy.py
+++ b/mapo/agents/off_mapo/off_mapo_policy.py
@@ -127,7 +127,7 @@ def actor_critic_gradients(policy, *_):
 def extra_action_feed_fn(policy):
     """Add exploration status to compute_actions feed dict."""
     return {
-        policy.evaluating: policy.config["evaluate"],
+        policy.evaluating: policy.evaluation,
         policy.pure_exploration_phase: policy.uniform_random,
     }
 
@@ -135,7 +135,7 @@ def extra_action_feed_fn(policy):
 def setup_early_mixins(policy, obs_space, action_space, config):
     """Initialize early stateful mixins."""
     # pylint: disable=unused-argument
-    ExplorationStateMixin.__init__(policy)
+    ExplorationStateMixin.__init__(policy, config["evaluate"])
 
 
 def create_separate_optimizers(policy, obs_space, action_space, config):
@@ -264,12 +264,17 @@ def build_actor_critic_models(policy, input_dict, obs_space, action_space, confi
 class ExplorationStateMixin:  # pylint: disable=too-few-public-methods
     """Adds method to toggle pure exploration phase."""
 
-    def __init__(self):
+    def __init__(self, evaluate):
         self.uniform_random = False
+        self.evaluation = evaluate
 
     def set_pure_exploration_phase(self, pure_exploration):
         """Set flag for computing uniform random actions."""
         self.uniform_random = pure_exploration
+
+    def evaluate(self, evaluate):
+        """Set flag for computing deterministic actions."""
+        self.evaluation = evaluate
 
 
 class TargetUpdatesMixin:  # pylint: disable=too-few-public-methods

--- a/mapo/agents/off_mapo/off_mapo_policy.py
+++ b/mapo/agents/off_mapo/off_mapo_policy.py
@@ -237,23 +237,24 @@ def build_actor_critic_models(policy, input_dict, obs_space, action_space, confi
             "space, or the multi-agent API."
         )
 
-    policy.q_model = build_continuous_q_function(obs_space, action_space, config)
-    policy.policy_model = build_deterministic_policy(obs_space, action_space, config)
-    policy.target_q_model = build_continuous_q_function(obs_space, action_space, config)
-    policy.target_policy_model = build_deterministic_policy(
-        obs_space, action_space, config
-    )
+    def make_actor():
+        return build_deterministic_policy(
+            obs_space, action_space, config["actor_model"]
+        )
+
+    def make_critic():
+        return build_continuous_q_function(
+            obs_space, action_space, config["critic_model"]
+        )
+
+    policy.policy_model, policy.target_policy_model = make_actor(), make_actor()
+    policy.q_model, policy.target_q_model = make_critic(), make_critic()
     policy.main_variables = policy.q_model.variables + policy.policy_model.variables
     policy.target_variables = (
         policy.target_q_model.variables + policy.target_policy_model.variables
     )
     if config["twin_q"]:
-        policy.twin_q_model = build_continuous_q_function(
-            obs_space, action_space, config
-        )
-        policy.target_twin_q_model = build_continuous_q_function(
-            obs_space, action_space, config
-        )
+        policy.twin_q_model, policy.target_twin_q_model = make_critic(), make_critic()
         policy.main_variables += policy.twin_q_model.variables
         policy.target_variables += policy.target_twin_q_model.variables
 

--- a/mapo/agents/off_mapo/tests/__init__.py
+++ b/mapo/agents/off_mapo/tests/__init__.py
@@ -1,0 +1,1 @@
+# pylint: disable=missing-docstring

--- a/mapo/agents/off_mapo/tests/test_delayed_updates.py
+++ b/mapo/agents/off_mapo/tests/test_delayed_updates.py
@@ -1,61 +1,60 @@
 """Tests regarding delayed policy updates in OffMAPO."""
 
 import numpy as np
-from ray.rllib.models import ModelCatalog
-from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.evaluation import RolloutWorker
 
 from mapo.tests.mock_env import MockEnv
 from mapo.agents.off_mapo.off_mapo_policy import OffMAPOTFPolicy
 
 
-def get_dummy_batch(policy):
-    """Get fake batch based on the policy's input."""
-    # pylint: disable=protected-access
-    def fake_array(tensor):
-        shape = tensor.shape.as_list()
-        shape[0] = 1
-        return np.zeros(shape, dtype=tensor.dtype.as_numpy_dtype)
-
-    dummy_batch = {
-        SampleBatch.CUR_OBS: fake_array(policy._obs_input),
-        SampleBatch.NEXT_OBS: fake_array(policy._obs_input),
-        SampleBatch.DONES: np.array([False], dtype=np.bool),
-        SampleBatch.ACTIONS: fake_array(
-            ModelCatalog.get_action_placeholder(policy.action_space)
-        ),
-        SampleBatch.REWARDS: np.array([0], dtype=np.float32),
-    }
-    if policy._obs_include_prev_action_reward:
-        dummy_batch.update(
-            {
-                SampleBatch.PREV_ACTIONS: fake_array(policy._prev_action_input),
-                SampleBatch.PREV_REWARDS: fake_array(policy._prev_reward_input),
-            }
-        )
-    state_init = policy.get_initial_state()
-    for idx, hid in enumerate(state_init):
-        dummy_batch["state_in_{}".format(idx)] = np.expand_dims(hid, 0)
-        dummy_batch["state_out_{}".format(idx)] = np.expand_dims(hid, 0)
-    if state_init:
-        dummy_batch["seq_lens"] = np.array([1], dtype=np.int32)
-    for key, val in policy.extra_compute_action_fetches().items():
-        dummy_batch[key] = fake_array(val)
-    return dummy_batch
-
-
 def test_update_optimizer_global_step():
     """Check that apply operations are run the correct number of times."""
     # pylint: disable=protected-access
-    env = MockEnv()
-    policy = OffMAPOTFPolicy(
-        env.observation_space, env.action_space, {"policy_delay": 2}
-    )
+    worker = RolloutWorker(MockEnv, OffMAPOTFPolicy, policy_config={"policy_delay": 2})
+    policy = worker.get_policy()
 
-    dummy_batch = get_dummy_batch(policy)
-    for _ in range(6):
-        policy.learn_on_batch(dummy_batch)
+    for _ in range(10):
+        policy.learn_on_batch(worker.sample())
 
     sess = policy.get_session()
-    assert sess.run(policy.global_step) == 6
-    assert sess.run(policy._actor_optimizer.iterations) == 3
-    assert sess.run(policy._critic_optimizer.iterations) == 6
+    assert sess.run(policy.global_step) == 10
+    assert sess.run(policy._actor_optimizer.iterations) == 5
+    assert sess.run(policy._critic_optimizer.iterations) == 10
+
+
+def test_actor_updates():
+    """Check that actor variables are only changed at the appropriate intervals."""
+    worker = RolloutWorker(MockEnv, OffMAPOTFPolicy, policy_config={"policy_delay": 2})
+    policy = worker.get_policy()
+
+    def get_actor_vars():
+        return policy.get_session().run(policy.policy_model.variables)
+
+    for iteration in range(1, 7):
+        before = get_actor_vars()
+        policy.learn_on_batch(worker.sample())
+        after = get_actor_vars()
+        all_close = all([np.allclose(varb, vara) for varb, vara in zip(before, after)])
+        if iteration % 2 == 0:
+            assert not all_close
+        else:
+            assert all_close
+
+
+def test_target_updates():
+    """Check that target variables are only changed at the appropriate intervals."""
+    worker = RolloutWorker(MockEnv, OffMAPOTFPolicy, policy_config={"policy_delay": 2})
+    policy = worker.get_policy()
+
+    def get_target_vars():
+        return policy.get_session().run(policy.target_variables)
+
+    for iteration in range(1, 7):
+        before = get_target_vars()
+        policy.learn_on_batch(worker.sample())
+        after = get_target_vars()
+        all_close = all([np.allclose(varb, vara) for varb, vara in zip(before, after)])
+        if iteration % 2 == 0:
+            assert not all_close
+        else:
+            assert all_close

--- a/mapo/agents/off_mapo/tests/test_delayed_updates.py
+++ b/mapo/agents/off_mapo/tests/test_delayed_updates.py
@@ -1,5 +1,5 @@
 """Tests regarding delayed policy updates in OffMAPO."""
-
+# pylint: disable=missing-docstring
 import numpy as np
 from ray.rllib.evaluation import RolloutWorker
 
@@ -7,8 +7,7 @@ from mapo.tests.mock_env import MockEnv
 from mapo.agents.off_mapo.off_mapo_policy import OffMAPOTFPolicy
 
 
-def test_initialization():
-    """Check if target networks are initialized correctly."""
+def test_target_network_initialization():
     worker = RolloutWorker(MockEnv, OffMAPOTFPolicy, policy_config={"policy_delay": 2})
     policy = worker.get_policy()
 
@@ -24,8 +23,7 @@ def test_initialization():
     )
 
 
-def test_update_optimizer_global_step():
-    """Check that apply operations are run the correct number of times."""
+def test_optimizer_global_step_update():
     # pylint: disable=protected-access
     worker = RolloutWorker(MockEnv, OffMAPOTFPolicy, policy_config={"policy_delay": 2})
     policy = worker.get_policy()
@@ -39,8 +37,7 @@ def test_update_optimizer_global_step():
     assert sess.run(policy._critic_optimizer.iterations) == 10
 
 
-def test_actor_updates():
-    """Check that actor variables are only changed at the appropriate intervals."""
+def test_actor_update_frequency():
     worker = RolloutWorker(MockEnv, OffMAPOTFPolicy, policy_config={"policy_delay": 2})
     policy = worker.get_policy()
 
@@ -58,8 +55,7 @@ def test_actor_updates():
             assert all_close
 
 
-def test_target_updates():
-    """Check that target variables are only changed at the appropriate intervals."""
+def test_target_update_frequency():
     worker = RolloutWorker(MockEnv, OffMAPOTFPolicy, policy_config={"policy_delay": 2})
     policy = worker.get_policy()
 

--- a/mapo/agents/off_mapo/tests/test_delayed_updates.py
+++ b/mapo/agents/off_mapo/tests/test_delayed_updates.py
@@ -1,0 +1,61 @@
+"""Tests regarding delayed policy updates in OffMAPO."""
+
+import numpy as np
+from ray.rllib.models import ModelCatalog
+from ray.rllib.policy.sample_batch import SampleBatch
+
+from mapo.tests.mock_env import MockEnv
+from mapo.agents.off_mapo.off_mapo_policy import OffMAPOTFPolicy
+
+
+def get_dummy_batch(policy):
+    """Get fake batch based on the policy's input."""
+    # pylint: disable=protected-access
+    def fake_array(tensor):
+        shape = tensor.shape.as_list()
+        shape[0] = 1
+        return np.zeros(shape, dtype=tensor.dtype.as_numpy_dtype)
+
+    dummy_batch = {
+        SampleBatch.CUR_OBS: fake_array(policy._obs_input),
+        SampleBatch.NEXT_OBS: fake_array(policy._obs_input),
+        SampleBatch.DONES: np.array([False], dtype=np.bool),
+        SampleBatch.ACTIONS: fake_array(
+            ModelCatalog.get_action_placeholder(policy.action_space)
+        ),
+        SampleBatch.REWARDS: np.array([0], dtype=np.float32),
+    }
+    if policy._obs_include_prev_action_reward:
+        dummy_batch.update(
+            {
+                SampleBatch.PREV_ACTIONS: fake_array(policy._prev_action_input),
+                SampleBatch.PREV_REWARDS: fake_array(policy._prev_reward_input),
+            }
+        )
+    state_init = policy.get_initial_state()
+    for idx, hid in enumerate(state_init):
+        dummy_batch["state_in_{}".format(idx)] = np.expand_dims(hid, 0)
+        dummy_batch["state_out_{}".format(idx)] = np.expand_dims(hid, 0)
+    if state_init:
+        dummy_batch["seq_lens"] = np.array([1], dtype=np.int32)
+    for key, val in policy.extra_compute_action_fetches().items():
+        dummy_batch[key] = fake_array(val)
+    return dummy_batch
+
+
+def test_update_optimizer_global_step():
+    """Check that apply operations are run the correct number of times."""
+    # pylint: disable=protected-access
+    env = MockEnv()
+    policy = OffMAPOTFPolicy(
+        env.observation_space, env.action_space, {"policy_delay": 2}
+    )
+
+    dummy_batch = get_dummy_batch(policy)
+    for _ in range(6):
+        policy.learn_on_batch(dummy_batch)
+
+    sess = policy.get_session()
+    assert sess.run(policy.global_step) == 6
+    assert sess.run(policy._actor_optimizer.iterations) == 3
+    assert sess.run(policy._critic_optimizer.iterations) == 6

--- a/mapo/agents/off_mapo/tests/test_delayed_updates.py
+++ b/mapo/agents/off_mapo/tests/test_delayed_updates.py
@@ -7,6 +7,23 @@ from mapo.tests.mock_env import MockEnv
 from mapo.agents.off_mapo.off_mapo_policy import OffMAPOTFPolicy
 
 
+def test_initialization():
+    """Check if target networks are initialized correctly."""
+    worker = RolloutWorker(MockEnv, OffMAPOTFPolicy, policy_config={"policy_delay": 2})
+    policy = worker.get_policy()
+
+    def get_main_target_vars():
+        main_vars = policy.get_session().run(policy.main_variables)
+        target_vars = policy.get_session().run(policy.target_variables)
+        return zip(main_vars, target_vars)
+
+    assert all([np.allclose(main, target) for main, target in get_main_target_vars()])
+    policy.learn_on_batch(worker.sample())
+    assert not all(
+        [np.allclose(main, target) for main, target in get_main_target_vars()]
+    )
+
+
 def test_update_optimizer_global_step():
     """Check that apply operations are run the correct number of times."""
     # pylint: disable=protected-access

--- a/mapo/agents/off_mapo/tests/test_exploration_state.py
+++ b/mapo/agents/off_mapo/tests/test_exploration_state.py
@@ -39,7 +39,7 @@ def test_pure_exploration():
         return np.squeeze(policy.compute_actions(obs.repeat(size, axis=0), [])[0])
 
     _, p_value = stats.kstest(rvs, cdf, N=2000)
-    assert p_value >= 0.1
+    assert p_value >= 0.05
 
 
 def test_iid_gaussian_exploration():
@@ -64,4 +64,4 @@ def test_iid_gaussian_exploration():
         return np.squeeze(policy.compute_actions(obs[None].repeat(size, axis=0), [])[0])
 
     _, p_value = stats.kstest(rvs, cdf, N=2000)
-    assert p_value >= 0.1
+    assert p_value >= 0.05

--- a/mapo/agents/off_mapo/tests/test_exploration_state.py
+++ b/mapo/agents/off_mapo/tests/test_exploration_state.py
@@ -1,4 +1,5 @@
 """Tests regarding exploration features in OffMAPO."""
+# pylint: disable=missing-docstring
 import numpy as np
 import scipy.stats as stats
 from ray.rllib.evaluation import RolloutWorker
@@ -7,8 +8,7 @@ from mapo.tests.mock_env import MockEnv
 from mapo.agents.off_mapo.off_mapo_policy import OffMAPOTFPolicy
 
 
-def test_evaluation():
-    """Check if compute_actions is deterministic when evaluating."""
+def test_deterministic_evaluation():
     worker = RolloutWorker(MockEnv, OffMAPOTFPolicy)
     policy = worker.get_policy()
     policy.evaluate(True)
@@ -23,7 +23,6 @@ def test_evaluation():
 
 
 def test_pure_exploration():
-    """Check if action distribution is uniform using the Kolmogorov-Smirnov test."""
     env = MockEnv({"action_dim": 1})
     ob_space, ac_space = env.observation_space, env.action_space
     policy = OffMAPOTFPolicy(ob_space, ac_space, {})
@@ -43,11 +42,12 @@ def test_pure_exploration():
     assert p_value >= 0.1
 
 
-def test_gaussian_exploration():
-    """Check if action distribution is normal using the Kolmogorov-Smirnov test."""
+def test_iid_gaussian_exploration():
     env = MockEnv({"action_dim": 1})
     policy = OffMAPOTFPolicy(
-        env.observation_space, env.action_space, {"exploration_gaussian_sigma": 0.5}
+        env.observation_space,
+        env.action_space,
+        {"exploration_noise_type": "gaussian", "exploration_gaussian_sigma": 0.5},
     )
 
     obs = env.observation_space.sample()

--- a/mapo/agents/off_mapo/tests/test_exploration_state.py
+++ b/mapo/agents/off_mapo/tests/test_exploration_state.py
@@ -1,0 +1,20 @@
+"""Tests regarding exploration features in OffMAPO."""
+import numpy as np
+from ray.rllib.evaluation import RolloutWorker
+
+from mapo.tests.mock_env import MockEnv
+from mapo.agents.off_mapo.off_mapo_policy import OffMAPOTFPolicy
+
+
+def test_evaluation():
+    """Check if compute_actions is deterministic when evaluating."""
+    worker = RolloutWorker(MockEnv, OffMAPOTFPolicy, policy_config={"evaluate": True})
+    policy = worker.get_policy()
+
+    for _ in range(3):
+        policy.learn_on_batch(worker.sample())
+
+    obs = MockEnv().observation_space.sample()
+    action1, _, _ = policy.compute_single_action(obs, [])
+    action2, _, _ = policy.compute_single_action(obs, [])
+    assert np.allclose(action1, action2)

--- a/mapo/agents/off_mapo/tests/test_exploration_state.py
+++ b/mapo/agents/off_mapo/tests/test_exploration_state.py
@@ -1,5 +1,6 @@
 """Tests regarding exploration features in OffMAPO."""
 import numpy as np
+import scipy.stats as stats
 from ray.rllib.evaluation import RolloutWorker
 
 from mapo.tests.mock_env import MockEnv
@@ -8,8 +9,9 @@ from mapo.agents.off_mapo.off_mapo_policy import OffMAPOTFPolicy
 
 def test_evaluation():
     """Check if compute_actions is deterministic when evaluating."""
-    worker = RolloutWorker(MockEnv, OffMAPOTFPolicy, policy_config={"evaluate": True})
+    worker = RolloutWorker(MockEnv, OffMAPOTFPolicy)
     policy = worker.get_policy()
+    policy.evaluate(True)
 
     for _ in range(3):
         policy.learn_on_batch(worker.sample())
@@ -18,3 +20,48 @@ def test_evaluation():
     action1, _, _ = policy.compute_single_action(obs, [])
     action2, _, _ = policy.compute_single_action(obs, [])
     assert np.allclose(action1, action2)
+
+
+def test_pure_exploration():
+    """Check if action distribution is uniform using the Kolmogorov-Smirnov test."""
+    env = MockEnv({"action_dim": 1})
+    ob_space, ac_space = env.observation_space, env.action_space
+    policy = OffMAPOTFPolicy(ob_space, ac_space, {})
+    policy.set_pure_exploration_phase(True)
+
+    obs = ob_space.sample()[None]
+
+    def cdf(var):
+        return stats.uniform.cdf(
+            var, loc=ac_space.low, scale=ac_space.high - ac_space.low
+        )
+
+    def rvs(size=1):
+        return np.squeeze(policy.compute_actions(obs.repeat(size, axis=0), [])[0])
+
+    _, p_value = stats.kstest(rvs, cdf, N=2000)
+    assert p_value >= 0.1
+
+
+def test_gaussian_exploration():
+    """Check if action distribution is normal using the Kolmogorov-Smirnov test."""
+    env = MockEnv({"action_dim": 1})
+    policy = OffMAPOTFPolicy(
+        env.observation_space, env.action_space, {"exploration_gaussian_sigma": 0.5}
+    )
+
+    obs = env.observation_space.sample()
+    policy.evaluate(True)
+    loc = np.squeeze(policy.compute_single_action(obs, [])[0])
+    policy.evaluate(False)
+
+    def cdf(var):
+        return stats.norm.cdf(
+            var, loc=loc, scale=policy.config["exploration_gaussian_sigma"]
+        )
+
+    def rvs(size=1):
+        return np.squeeze(policy.compute_actions(obs[None].repeat(size, axis=0), [])[0])
+
+    _, p_value = stats.kstest(rvs, cdf, N=2000)
+    assert p_value >= 0.1

--- a/mapo/agents/registry.py
+++ b/mapo/agents/registry.py
@@ -7,4 +7,10 @@ def _import_mapo():
     return mapo.MAPOTrainer
 
 
-ALGORITHMS = {"MAPO": _import_mapo}
+def _import_off_mapo():
+    from mapo.agents import off_mapo
+
+    return off_mapo.OffMAPOTrainer
+
+
+ALGORITHMS = {"MAPO": _import_mapo, "OffMAPO": _import_off_mapo}

--- a/mapo/models/fcnet.py
+++ b/mapo/models/fcnet.py
@@ -1,0 +1,26 @@
+"""Utilities for constructing fully connected networks in Keras."""
+from tensorflow import keras
+
+DEFAULT_CONFIG = {
+    "hidden_activation": "relu",
+    "hidden_units": [400, 300],
+    "layer_normalization": False,
+}
+
+
+def build_fcnet(input_shape, config=None):
+    """Construct a fully connected Keras model on inputs."""
+    config = config or {}
+    config = {**DEFAULT_CONFIG, **config}
+    activation = config["hidden_activation"]
+    layer_norm = config["layer_normalization"]
+
+    inputs = output = keras.Input(shape=input_shape)
+    for units in config["hidden_units"]:
+        if layer_norm:
+            output = keras.layers.Dense(units=units)(output)
+            output = keras.layers.LayerNormalization(output)
+            output = keras.activations.get(activation)(output)
+        else:
+            output = keras.layers.Dense(units=units, activation=activation)(output)
+    return keras.Model(inputs=inputs, outputs=output)

--- a/mapo/models/policy.py
+++ b/mapo/models/policy.py
@@ -1,8 +1,7 @@
 """Utilities for constructing policy approximators."""
 from tensorflow import keras
+from mapo.models.fcnet import build_fcnet
 from mapo.models.layers import ActionSquashingLayer
-
-DEFAULT_CONFIG = {"hidden_activation": "relu", "hidden_units": [400, 300]}
 
 
 def build_deterministic_policy(obs_space, action_space, config=None):
@@ -11,15 +10,9 @@ def build_deterministic_policy(obs_space, action_space, config=None):
 
     Assumes both obs_space and action_space are gym.spaces.Box instances.
     """
-    config = config or {}
-    config = {**DEFAULT_CONFIG, **config}
-
     policy_input = keras.Input(shape=obs_space.shape)
-    activation = config["hidden_activation"]
-    policy_out = policy_input
-    for units in config["hidden_units"]:
-        policy_out = keras.layers.Dense(units=units, activation=activation)(policy_out)
 
+    policy_out = build_fcnet(policy_input.shape, config=config)(policy_input)
     policy_out = keras.layers.Dense(units=action_space.shape[0])(policy_out)
     policy_out = ActionSquashingLayer(action_space)(policy_out)
     return keras.Model(inputs=policy_input, outputs=policy_out)

--- a/mapo/models/policy.py
+++ b/mapo/models/policy.py
@@ -1,4 +1,4 @@
-"""Utilities for contruction policy approximators."""
+"""Utilities for constructing policy approximators."""
 from tensorflow import keras
 from mapo.models.layers import ActionSquashingLayer
 

--- a/mapo/models/policy.py
+++ b/mapo/models/policy.py
@@ -2,7 +2,7 @@
 from tensorflow import keras
 from mapo.models.layers import ActionSquashingLayer
 
-DEFAULT_CONFIG = {"hidden_activation": "relu", "hidden_units": [64, 64]}
+DEFAULT_CONFIG = {"hidden_activation": "relu", "hidden_units": [400, 300]}
 
 
 def build_deterministic_policy(obs_space, action_space, config=None):
@@ -17,8 +17,8 @@ def build_deterministic_policy(obs_space, action_space, config=None):
     policy_input = keras.Input(shape=obs_space.shape)
     activation = config["hidden_activation"]
     policy_out = policy_input
-    for hidden in config["hidden_units"]:
-        policy_out = keras.layers.Dense(units=hidden, activation=activation)(policy_out)
+    for units in config["hidden_units"]:
+        policy_out = keras.layers.Dense(units=units, activation=activation)(policy_out)
 
     policy_out = keras.layers.Dense(units=action_space.shape[0])(policy_out)
     policy_out = ActionSquashingLayer(action_space)(policy_out)

--- a/mapo/models/q_function.py
+++ b/mapo/models/q_function.py
@@ -1,7 +1,7 @@
 """Utilities for constructing Q function approximators."""
 from tensorflow import keras
 
-DEFAULT_CONFIG = {"hidden_activation": "relu", "hidden_units": [64, 64]}
+DEFAULT_CONFIG = {"hidden_activation": "relu", "hidden_units": [400, 300]}
 
 
 def build_continuous_q_function(obs_space, action_space, config=None):
@@ -15,10 +15,9 @@ def build_continuous_q_function(obs_space, action_space, config=None):
 
     obs_input = keras.Input(shape=obs_space.shape)
     action_input = keras.Input(shape=action_space.shape)
+    output = keras.layers.Concatenate(axis=1)([obs_input, action_input])
     activation = config["hidden_activation"]
-
-    output = keras.layers.concatenate([obs_input, action_input])
-    for hidden in config["hidden_units"]:
-        output = keras.layers.Dense(units=hidden, activation=activation)(output)
+    for units in config["hidden_units"]:
+        output = keras.layers.Dense(units=units, activation=activation)(output)
     output = keras.layers.Dense(units=1, activation=None)(output)
     return keras.Model(inputs=[obs_input, action_input], outputs=output)

--- a/mapo/models/q_function.py
+++ b/mapo/models/q_function.py
@@ -1,7 +1,6 @@
 """Utilities for constructing Q function approximators."""
 from tensorflow import keras
-
-DEFAULT_CONFIG = {"hidden_activation": "relu", "hidden_units": [400, 300]}
+from mapo.models.fcnet import build_fcnet
 
 
 def build_continuous_q_function(obs_space, action_space, config=None):
@@ -10,14 +9,10 @@ def build_continuous_q_function(obs_space, action_space, config=None):
 
     Assumes both obs_space and action_space are gym.spaces.Box instances.
     """
-    config = config or {}
-    config = {**DEFAULT_CONFIG, **config}
-
     obs_input = keras.Input(shape=obs_space.shape)
     action_input = keras.Input(shape=action_space.shape)
     output = keras.layers.Concatenate(axis=1)([obs_input, action_input])
-    activation = config["hidden_activation"]
-    for units in config["hidden_units"]:
-        output = keras.layers.Dense(units=units, activation=activation)(output)
+
+    output = build_fcnet(output.shape, config=config)(output)
     output = keras.layers.Dense(units=1, activation=None)(output)
     return keras.Model(inputs=[obs_input, action_input], outputs=output)

--- a/mapo/models/tests/test_policy.py
+++ b/mapo/models/tests/test_policy.py
@@ -1,4 +1,5 @@
 """Tests for policy keras model."""
+# pylint: disable=missing-docstring
 import tensorflow as tf
 from tensorflow import keras
 from mapo.tests.mock_env import MockEnv
@@ -6,8 +7,7 @@ from mapo.models.policy import build_deterministic_policy
 from mapo.models.layers import ActionSquashingLayer
 
 
-def test_shape():
-    """Check if policy output has a consistent shape."""
+def test_policy_output_has_consitent_shape():
     env = MockEnv()
     ob_space, ac_space = env.observation_space, env.action_space
     policy_model = build_deterministic_policy(ob_space, ac_space)
@@ -16,8 +16,7 @@ def test_shape():
     assert output.shape.as_list() == tf.TensorShape((None,) + ac_space.shape).as_list()
 
 
-def test_is_serializable():
-    """Check if policy can export config and be recreated from it."""
+def test_policy_model_is_serializable():
     env = MockEnv()
     ob_space, ac_space = env.observation_space, env.action_space
     policy_model = build_deterministic_policy(ob_space, ac_space)

--- a/mapo/models/tests/test_q_function.py
+++ b/mapo/models/tests/test_q_function.py
@@ -1,12 +1,12 @@
 """Tests for Q keras model."""
+# pylint: disable=missing-docstring
 import tensorflow as tf
 from tensorflow import keras
 from mapo.tests.mock_env import MockEnv
 from mapo.models.q_function import build_continuous_q_function
 
 
-def test_shape():
-    """Check if Q function output has a consistent shape."""
+def test_q_function_output_has_consistent_shape():
     env = MockEnv()
     ob_space, ac_space = env.observation_space, env.action_space
     q_model = build_continuous_q_function(ob_space, ac_space)
@@ -16,8 +16,7 @@ def test_shape():
     assert output.shape.as_list() == tf.TensorShape((None, 1)).as_list()
 
 
-def test_is_serializable():
-    """Check if Q function can export config and be recreated from it."""
+def test_q_function_model_is_serializable():
     env = MockEnv()
     ob_space, ac_space = env.observation_space, env.action_space
     q_model = build_continuous_q_function(ob_space, ac_space)

--- a/mapo/tests/mock_env.py
+++ b/mapo/tests/mock_env.py
@@ -8,11 +8,12 @@ class MockEnv(gym.Env):  # pylint: disable=abstract-method
     """Dummy environment with continuous action space."""
 
     def __init__(self, config=None):
-        self.config = config
+        self.config = config or {"action_dim": 4}
         self.horizon = 200
         self.time = 0
         self.observation_space = Box(high=1, low=-1, shape=(4,), dtype=np.float32)
-        self.action_space = Box(high=1, low=-1, shape=(2,), dtype=np.float32)
+        action_dim = self.config["action_dim"]
+        self.action_space = Box(high=1, low=-1, shape=(action_dim,), dtype=np.float32)
 
     def reset(self):
         self.time = 0

--- a/mapo/tests/test_checkpoint.py
+++ b/mapo/tests/test_checkpoint.py
@@ -1,21 +1,24 @@
 """Tests for agent saving and loading."""
+import pytest
 import numpy as np
 import ray
 from ray.tune import register_env
 from mapo.tests.mock_env import MockEnv
-from mapo.agents.mapo import MAPOTrainer
+from mapo.agents.registry import ALGORITHMS
 
 
-def test_checkpoint_restore(tmpdir):
+@pytest.mark.parametrize("get_trainer", list(ALGORITHMS.values()))
+def test_checkpoint_restore(tmpdir, get_trainer):
     """
     Check if agents can be succesfully restored.
 
     Assumes the result of `compute_action` is deterministic for a given observation.
     """
-    ray.init()
+    ray.init(ignore_reinit_error=True)
     register_env("test", lambda _: MockEnv())
-    agent1 = MAPOTrainer(env="test")
-    agent2 = MAPOTrainer(env="test")
+    trainer = get_trainer()
+    agent1 = trainer(env="test")
+    agent2 = trainer(env="test")
 
     for _ in range(3):
         agent1.train()

--- a/mapo/tests/test_checkpoint.py
+++ b/mapo/tests/test_checkpoint.py
@@ -1,8 +1,8 @@
 """Tests for agent saving and loading."""
 import pytest
-import numpy as np
 import ray
 from ray.tune import register_env
+from ray.rllib.tests.test_checkpoint_restore import get_mean_action
 from mapo.tests.mock_env import MockEnv
 from mapo.agents.registry import ALGORITHMS
 
@@ -15,7 +15,7 @@ def test_checkpoint_restore(tmpdir, get_trainer):
     Assumes the result of `compute_action` is deterministic for a given observation.
     """
     ray.init(ignore_reinit_error=True)
-    register_env("test", lambda _: MockEnv())
+    register_env("test", lambda _: MockEnv({"action_dim": 1}))
     trainer = get_trainer()
     agent1 = trainer(env="test")
     agent2 = trainer(env="test")
@@ -26,5 +26,6 @@ def test_checkpoint_restore(tmpdir, get_trainer):
 
     env = MockEnv()
     obs = env.observation_space.sample()
-    action1, action2 = agent1.compute_action(obs), agent2.compute_action(obs)
-    assert np.allclose(action1, action2)
+    mean_action1 = get_mean_action(agent1, obs)
+    mean_action2 = get_mean_action(agent2, obs)
+    assert abs(mean_action1 - mean_action2) <= 0.1

--- a/mapo/tests/test_checkpoint.py
+++ b/mapo/tests/test_checkpoint.py
@@ -2,13 +2,13 @@
 import pytest
 import ray
 from ray.tune import register_env
-
+from ray.tune.logger import NoopLogger
 from ray.rllib.tests.test_checkpoint_restore import get_mean_action
+
 from mapo.tests.mock_env import MockEnv
 from mapo.agents.registry import ALGORITHMS
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("get_trainer", list(ALGORITHMS.values()))
 def test_checkpoint_restore(tmpdir, get_trainer):
     """
@@ -21,7 +21,12 @@ def test_checkpoint_restore(tmpdir, get_trainer):
     trainer = get_trainer()
 
     def get_agent():
-        return trainer(env="test", config={"train_batch_size": 100, "num_workers": 0})
+        config = {"train_batch_size": 100, "num_workers": 0}
+
+        def test_logger_creator(_):
+            return NoopLogger(None, None)
+
+        return trainer(env="test", config=config, logger_creator=test_logger_creator)
 
     agent1 = get_agent()
     agent2 = get_agent()

--- a/mapo/tests/test_checkpoint.py
+++ b/mapo/tests/test_checkpoint.py
@@ -2,11 +2,13 @@
 import pytest
 import ray
 from ray.tune import register_env
+
 from ray.rllib.tests.test_checkpoint_restore import get_mean_action
 from mapo.tests.mock_env import MockEnv
 from mapo.agents.registry import ALGORITHMS
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("get_trainer", list(ALGORITHMS.values()))
 def test_checkpoint_restore(tmpdir, get_trainer):
     """
@@ -17,8 +19,12 @@ def test_checkpoint_restore(tmpdir, get_trainer):
     ray.init(ignore_reinit_error=True)
     register_env("test", lambda _: MockEnv({"action_dim": 1}))
     trainer = get_trainer()
-    agent1 = trainer(env="test")
-    agent2 = trainer(env="test")
+
+    def get_agent():
+        return trainer(env="test", config={"train_batch_size": 100, "num_workers": 0})
+
+    agent1 = get_agent()
+    agent2 = get_agent()
 
     for _ in range(3):
         agent1.train()

--- a/mapo/tests/test_rollout.py
+++ b/mapo/tests/test_rollout.py
@@ -1,12 +1,17 @@
 """Tests for agent-environment interface."""
+import pytest
+
 from mapo.tests.mock_env import MockEnv
-from mapo.agents.mapo.mapo_policy import MAPOTFPolicy
+from mapo.agents.registry import ALGORITHMS
 
 
-def test_compute_single_action():
+@pytest.mark.parametrize("get_trainer", list(ALGORITHMS.values()))
+def test_compute_single_action(get_trainer):
     """Test if policy returns single action from the correct space."""
     env = MockEnv()
-    policy = MAPOTFPolicy(env.observation_space, env.action_space, {})
+    trainer = get_trainer()
+    # pylint: disable=protected-access
+    policy = trainer._policy(env.observation_space, env.action_space, {})
 
     obs = env.reset()
     # the list is a placeholder for RNN state inputs

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,13 @@ setup(
     url="",
     packages=find_packages(),
     scripts=[],
-    install_requires=["gym", "ray[rllib]", "tensorflow<2.0.0", "pandas", "requests"],
+    install_requires=[
+        "gym",
+        "ray[rllib]==0.7.2",
+        "tensorflow<2.0.0",
+        "pandas",
+        "requests",
+    ],
     include_package_data=True,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Adds a new trainer for off-policy learning with `MAPO`. The name "OffMAPO" is a placeholder. 

This is basically a simple implementation of `TD3` which we can build upon later. For this PR, successful learning was actually a concern. Therefore I tested if the algorithm showed promising learning curves in the `HalfCheetah-v2` environment. The following is a plot of the the average evaluation return against the number of time steps taken in the environment.
![ray_tune_evaluation_episode_reward_mean](https://user-images.githubusercontent.com/12701614/62046548-93adae80-b1de-11e9-8ab0-b7eb13c19ed0.png)
The hyperparameters used were equivalent to the ones used in [spinninup's benchmark](https://spinningup.openai.com/en/latest/spinningup/bench.html#experiment-details).
