### PR TITLE
Bugfix/correct model arguments

### DIFF
--- a/mapo/agents/mapo/mapo.py
+++ b/mapo/agents/mapo/mapo.py
@@ -5,6 +5,8 @@ import logging
 from ray.rllib.agents.trainer import with_common_config
 from ray.rllib.agents.trainer_template import build_trainer
 from mapo.agents.mapo.mapo_policy import MAPOTFPolicy
+from mapo.models.q_function import DEFAULT_CONFIG as ACTOR_MODEL_CONFIG
+from mapo.models.policy import DEFAULT_CONFIG as CRITIC_MODEL_CONFIG
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -12,14 +14,8 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 DEFAULT_CONFIG = with_common_config(
     {
         # === Model ===
-        # Process the observation input tensors with these hidden layers.
-        "actor_hiddens": [64, 64],
-        # Hidden layers activation of the policy network
-        "actor_hidden_activation": "relu",
-        # Process the observation and action input tensors with these hidden layers.
-        "critic_hiddens": [64, 64],
-        # Hidden layers activation of the critic.
-        "critic_hidden_activation": "relu",
+        "actor_model": ACTOR_MODEL_CONFIG,
+        "critic_model": CRITIC_MODEL_CONFIG,
         # === Optimization ===
         # Learning rate for the critic (Q-function) optimizer.
         "critic_lr": 1e-3,

--- a/mapo/agents/mapo/mapo_policy.py
+++ b/mapo/agents/mapo/mapo_policy.py
@@ -84,8 +84,12 @@ def create_separate_optimizers(policy, obs_space, action_space, config):
 
 def build_actor_critic_models(policy, input_dict, obs_space, action_space, config):
     """Construct actor and critic keras models, and return actor action tensor."""
-    policy.q_function = build_continuous_q_function(obs_space, action_space, config)
-    policy.policy = build_deterministic_policy(obs_space, action_space, config)
+    policy.q_function = build_continuous_q_function(
+        obs_space, action_space, config["critic_model"]
+    )
+    policy.policy = build_deterministic_policy(
+        obs_space, action_space, config["actor_model"]
+    )
 
     actions = policy.policy(input_dict[SampleBatch.CUR_OBS])
     return actions, None

--- a/mapo/models/layers/action_squashing_layer.py
+++ b/mapo/models/layers/action_squashing_layer.py
@@ -1,6 +1,7 @@
 """Custom layer for box constrained actions."""
 import tensorflow as tf
 from tensorflow import keras
+from ray.rllib.utils.annotations import override
 
 
 class ActionSquashingLayer(keras.layers.Layer):
@@ -11,11 +12,13 @@ class ActionSquashingLayer(keras.layers.Layer):
         action_space (gym.spaces.Space): An action space of a gym environment
     """
 
-    def __init__(self, action_space):
-        super().__init__()
+    def __init__(self, action_space, **kwargs):
+        super().__init__(**kwargs)
+        self.action_space = action_space
         self.low = action_space.low[None]
         self.action_range = (action_space.high - action_space.low)[None]
 
+    @override(keras.layers.Layer)
     def call(self, inputs, **kwargs):
         """Returns the tensor of the multi-head layer's output.
 
@@ -26,3 +29,9 @@ class ActionSquashingLayer(keras.layers.Layer):
         """
         action_range = self.action_range
         return tf.math.sigmoid(inputs / action_range) * action_range + self.low
+
+    @override(keras.layers.Layer)
+    def get_config(self):
+        config = {"action_space": self.action_space}
+        base_config = super().get_config()
+        return {**base_config, **config}

--- a/mapo/models/q_function.py
+++ b/mapo/models/q_function.py
@@ -4,7 +4,7 @@ from tensorflow import keras
 DEFAULT_CONFIG = {"hidden_activation": "relu", "hidden_units": [64, 64]}
 
 
-def build_continuous_q_function(obs_space, action_space, config):
+def build_continuous_q_function(obs_space, action_space, config=None):
     """
     Construct continuous Q function keras model.
 
@@ -15,10 +15,10 @@ def build_continuous_q_function(obs_space, action_space, config):
 
     obs_input = keras.Input(shape=obs_space.shape)
     action_input = keras.Input(shape=action_space.shape)
-    activation = config["critic_hidden_activation"]
+    activation = config["hidden_activation"]
 
     output = keras.layers.concatenate([obs_input, action_input])
-    for hidden in config["critic_hiddens"]:
+    for hidden in config["hidden_units"]:
         output = keras.layers.Dense(units=hidden, activation=activation)(output)
     output = keras.layers.Dense(units=1, activation=None)(output)
     return keras.Model(inputs=[obs_input, action_input], outputs=output)

--- a/mapo/models/tests/__init__.py
+++ b/mapo/models/tests/__init__.py
@@ -1,0 +1,1 @@
+# pylint: disable=missing-docstring

--- a/mapo/models/tests/test_policy.py
+++ b/mapo/models/tests/test_policy.py
@@ -1,0 +1,24 @@
+"""Tests for policy keras model."""
+import tensorflow as tf
+from tensorflow import keras
+from mapo.tests.mock_env import MockEnv
+from mapo.models.policy import build_deterministic_policy
+
+
+def test_shape():
+    """Check if policy output has a consistent shape."""
+    env = MockEnv()
+    ob_space, ac_space = env.observation_space, env.action_space
+    policy_model = build_deterministic_policy(ob_space, ac_space)
+    obs = tf.placeholder(dtype=ob_space.dtype, shape=(None,) + ob_space.shape)
+    output = policy_model(obs)
+    assert output.shape.as_list() == tf.TensorShape((None,) + ac_space.shape).as_list()
+
+
+def test_is_serializable():
+    """Check if policy can export config and be recreated from it."""
+    env = MockEnv()
+    ob_space, ac_space = env.observation_space, env.action_space
+    policy_model = build_deterministic_policy(ob_space, ac_space)
+    policy_config = policy_model.get_config()
+    keras.Model.from_config(policy_config)

--- a/mapo/models/tests/test_policy.py
+++ b/mapo/models/tests/test_policy.py
@@ -3,6 +3,7 @@ import tensorflow as tf
 from tensorflow import keras
 from mapo.tests.mock_env import MockEnv
 from mapo.models.policy import build_deterministic_policy
+from mapo.models.layers import ActionSquashingLayer
 
 
 def test_shape():
@@ -21,4 +22,7 @@ def test_is_serializable():
     ob_space, ac_space = env.observation_space, env.action_space
     policy_model = build_deterministic_policy(ob_space, ac_space)
     policy_config = policy_model.get_config()
-    keras.Model.from_config(policy_config)
+    keras.Model.from_config(
+        policy_config,
+        custom_objects={ActionSquashingLayer.__name__: ActionSquashingLayer},
+    )

--- a/mapo/models/tests/test_q_function.py
+++ b/mapo/models/tests/test_q_function.py
@@ -1,0 +1,25 @@
+"""Tests for Q keras model."""
+import tensorflow as tf
+from tensorflow import keras
+from mapo.tests.mock_env import MockEnv
+from mapo.models.q_function import build_continuous_q_function
+
+
+def test_shape():
+    """Check if Q function output has a consistent shape."""
+    env = MockEnv()
+    ob_space, ac_space = env.observation_space, env.action_space
+    q_model = build_continuous_q_function(ob_space, ac_space)
+    obs = tf.placeholder(dtype=ob_space.dtype, shape=(None,) + ob_space.shape)
+    actions = tf.placeholder(dtype=ac_space.dtype, shape=(None,) + ac_space.shape)
+    output = q_model([obs, actions])
+    assert output.shape.as_list() == tf.TensorShape((None, 1)).as_list()
+
+
+def test_is_serializable():
+    """Check if Q function can export config and be recreated from it."""
+    env = MockEnv()
+    ob_space, ac_space = env.observation_space, env.action_space
+    q_model = build_continuous_q_function(ob_space, ac_space)
+    q_config = q_model.get_config()
+    keras.Model.from_config(q_config)


### PR DESCRIPTION
We defined default configurations for policy and Q function models, but we were not using these configurations in `MAPOTrainer`.

I also took this opportunity to add simple tests to our models.