### PR TITLE
Feature/mapo running script

### DIFF
--- a/mapo/__init__.py
+++ b/mapo/__init__.py
@@ -1,25 +1,6 @@
 """MAPO: Model-Aware Policy Optimization in RLlib."""
 
 
-def register_all_environments():
-    """Register all custom environments in gym."""
-    from gym.envs.registration import register
-
-    register(
-        id="Navigation-v0",
-        entry_point="mapo.envs:NavigationEnv",
-        max_episode_steps=100,
-        kwargs={"deceleration_zones": {}},
-    )
-
-    register(
-        id="Navigation-v1",
-        entry_point="mapo.envs:NavigationEnv",
-        max_episode_steps=100,
-        kwargs={},
-    )
-
-
 def register_all_agents():
     """Register all trainer names in Tune."""
     from ray.tune import register_trainable
@@ -27,3 +8,12 @@ def register_all_agents():
 
     for name, trainer_import in ALGORITHMS.items():
         register_trainable(name, trainer_import())
+
+
+def register_all_environments():
+    """Register all custom environments in Tune."""
+    from ray.tune import register_env
+    from mapo.envs.registry import ENVS
+
+    for name, env_import in ENVS.items():
+        register_env(name, env_import)

--- a/mapo/agents/mapo/mapo.py
+++ b/mapo/agents/mapo/mapo.py
@@ -12,6 +12,9 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 DEFAULT_CONFIG = with_common_config(
     {
+        # === MAPO ===
+        # How many samples to draw from the dynamics model
+        "branching_factor": 1,
         # === Model ===
         # actor and critic network configuration
         "model": merge_dicts(

--- a/mapo/agents/mapo/mapo.py
+++ b/mapo/agents/mapo/mapo.py
@@ -37,6 +37,8 @@ DEFAULT_CONFIG = with_common_config(
         "actor_lr": 1e-3,
         # delayed policy update
         "policy_delay": 1,
+        # delayed critic update
+        "critic_delay": 1,
         # Which model-learning optimization to use
         # Valid values: "mle" (Maximum Likelihood Estimation),
         # "pg-aware" (DPG-aware loss function),

--- a/mapo/agents/mapo/mapo_model.py
+++ b/mapo/agents/mapo/mapo_model.py
@@ -4,6 +4,7 @@ from ray.rllib.models.preprocessors import get_preprocessor
 from ray.rllib.models.tf.tf_modelv2 import TFModelV2
 from ray.rllib.utils.annotations import override
 
+from mapo.models import obs_input, action_input
 from mapo.models.policy import build_deterministic_policy
 from mapo.models.q_function import build_continuous_q_function
 from mapo.models.dynamics import GaussianDynamicsModel
@@ -51,6 +52,8 @@ class MAPOModel(TFModelV2):  # pylint: disable=abstract-method
         models["dynamics"] = GaussianDynamicsModel(
             obs_space, action_space, **model_config["custom_options"]["dynamics"]
         )
+        # Hack to create dynamics variables on initialization
+        models["dynamics"]([obs_input(obs_space), action_input(action_space)])
         self.models = models
         self.register_variables(
             [variable for model in models.values() for variable in model.variables]

--- a/mapo/agents/mapo/mapo_policy.py
+++ b/mapo/agents/mapo/mapo_policy.py
@@ -91,9 +91,9 @@ def create_separate_optimizers(policy, config):
     policy.global_step = tf.Variable(0, trainable=False)
 
 
-def compute_separate_gradients(policy, *_):
+def compute_separate_gradients(policy, optimizer, loss):
     """Create compute gradients ops using separate optimizers."""
-    # pylint: disable=protected-access
+    # pylint: disable=protected-access,unused-argument
     actor_variables = policy.model.actor_variables
     critic_variables = policy.model.critic_variables
     dynamics_variables = policy.model.dynamics_variables
@@ -117,14 +117,14 @@ def compute_separate_gradients(policy, *_):
     )
 
 
-def apply_gradients_with_delays(policy, *_):
+def apply_gradients_with_delays(policy, optimizer, grads_and_vars):
     """
     Update actor and critic models with different frequencies.
 
     For policy gradient, update policy net one time v.s. update critic net
     `policy_delay` time(s). Also use `policy_delay` for target networks update.
     """
-    # pylint: disable=protected-access
+    # pylint: disable=protected-access,unused-argument
     with tf.control_dependencies([policy.global_step.assign_add(1)]):
         # Critic updates
         critic_op = policy._critic_optimizer.apply_gradients(

--- a/mapo/agents/mapo/off_mapo.py
+++ b/mapo/agents/mapo/off_mapo.py
@@ -48,8 +48,6 @@ DEFAULT_CONFIG = merge_dicts(
         "target_noise_clip": 0.5,
         # delayed policy update
         "policy_delay": 2,
-        # delayed critic update
-        "critic_delay": 1,
         # How many environment steps to take before learning starts.
         "learning_starts": 0,
         # === Replay buffer ===

--- a/mapo/agents/mapo/off_mapo.py
+++ b/mapo/agents/mapo/off_mapo.py
@@ -14,9 +14,6 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 DEFAULT_CONFIG = merge_dicts(
     BASE_CONFIG,
     {
-        # === MAPO ===
-        # How many samples to draw from the dynamics model
-        "branching_factor": 1,
         # === Model ===
         # twin Q-net
         "twin_q": True,

--- a/mapo/agents/mapo/off_mapo_policy.py
+++ b/mapo/agents/mapo/off_mapo_policy.py
@@ -9,38 +9,32 @@ from ray.rllib.models.catalog import ModelCatalog
 from ray.rllib.utils.error import UnsupportedSpaceException
 
 from mapo.agents.mapo.mapo_policy import (
+    AgentComponents,
     _build_dynamics_mle_loss,
     create_separate_optimizers,
     compute_separate_gradients,
 )
 
 
-def _build_critic_targets(policy, batch_tensors):
+def _build_critic_targets(batch_tensors, model, action_space, config):
     rewards, dones, next_obs = (
         batch_tensors[SampleBatch.REWARDS],
         batch_tensors[SampleBatch.DONES],
         batch_tensors[SampleBatch.NEXT_OBS],
     )
-    gamma = policy.config["gamma"]
-    model = policy.model
+    gamma = config["gamma"]
     next_action = model.compute_actions(next_obs, target=True)
-    if policy.config["smooth_target_policy"]:
-        epsilon = tf.random.normal(
-            tf.shape(next_action), stddev=policy.config["target_noise"]
-        )
+    if config["smooth_target_policy"]:
+        epsilon = tf.random.normal(tf.shape(next_action), stddev=config["target_noise"])
         epsilon = tf.clip_by_value(
-            epsilon,
-            -policy.config["target_noise_clip"],
-            policy.config["target_noise_clip"],
+            epsilon, -config["target_noise_clip"], config["target_noise_clip"]
         )
         next_action = next_action + epsilon
-        next_action = tf.clip_by_value(
-            next_action, policy.action_space.low, policy.action_space.high
-        )
+        next_action = tf.clip_by_value(next_action, action_space.low, action_space.high)
     next_q_values = tf.squeeze(
         model.compute_q_values(next_obs, next_action, target=True)
     )
-    if policy.config["twin_q"]:
+    if config["twin_q"]:
         twin_q_values = model.compute_twin_q_values(next_obs, next_action, target=True)
         next_q_values = tf.math.minimum(next_q_values, tf.squeeze(twin_q_values))
     # Do not bootstrap if the state is terminal
@@ -48,39 +42,38 @@ def _build_critic_targets(policy, batch_tensors):
     return tf.compat.v2.where(dones, x=rewards, y=bootstrapped)
 
 
-def _build_critic_loss(policy, batch_tensors):
+def _build_critic_loss(batch_tensors, model, action_space, config):
     obs, actions = (
         batch_tensors[SampleBatch.CUR_OBS],
         batch_tensors[SampleBatch.ACTIONS],
     )
-    target_q_values = _build_critic_targets(policy, batch_tensors)
+    target_q_values = _build_critic_targets(batch_tensors, model, action_space, config)
     q_loss_criterion = keras.losses.MeanSquaredError()
-    q_pred = tf.squeeze(policy.model.compute_q_values(obs, actions))
-    q_stats = {
+    q_pred = tf.squeeze(model.compute_q_values(obs, actions))
+    fetches = {
         "q_mean": tf.reduce_mean(q_pred),
         "q_max": tf.reduce_max(q_pred),
         "q_min": tf.reduce_min(q_pred),
     }
-    policy.loss_stats.update(q_stats)
     critic_loss = q_loss_criterion(q_pred, target_q_values)
-    if policy.config["twin_q"]:
-        twin_q_pred = tf.squeeze(policy.model.compute_twin_q_values(obs, actions))
-        twin_q_stats = {
-            "twin_q_mean": tf.reduce_mean(twin_q_pred),
-            "twin_q_max": tf.reduce_max(twin_q_pred),
-            "twin_q_min": tf.reduce_min(twin_q_pred),
-        }
-        policy.loss_stats.update(twin_q_stats)
+    if config["twin_q"]:
+        twin_q_pred = tf.squeeze(model.compute_twin_q_values(obs, actions))
+        fetches.update(
+            {
+                "twin_q_mean": tf.reduce_mean(twin_q_pred),
+                "twin_q_max": tf.reduce_max(twin_q_pred),
+                "twin_q_min": tf.reduce_min(twin_q_pred),
+            }
+        )
         twin_q_loss = q_loss_criterion(twin_q_pred, target_q_values)
         critic_loss += twin_q_loss
-    return critic_loss
+    return critic_loss, fetches
 
 
-def _build_actor_loss(policy, batch_tensors):
+def _build_actor_loss(batch_tensors, model, config):
     obs = batch_tensors[SampleBatch.CUR_OBS]
-    gamma = policy.config["gamma"]
-    model = policy.model
-    n_samples = policy.config["branching_factor"]
+    gamma = config["gamma"]
+    n_samples = config["branching_factor"]
 
     policy_action = model.compute_actions(obs)
     sampled_next_state, next_state_log_prob = model.compute_log_prob_sampled(
@@ -98,7 +91,7 @@ def build_mapo_losses(policy, batch_tensors):
     """Contruct dynamics (MLE/PG-aware), critic (Fitted Q) and actor (MADPG) losses."""
     policy.loss_stats = {}
     if policy.config["model_loss"] == "mle":
-        policy.dynamics_loss = _build_dynamics_mle_loss(batch_tensors, policy.model)
+        dynamics_loss = _build_dynamics_mle_loss(batch_tensors, policy.model)
     elif policy.config["model_loss"] == "pg-aware":
         raise NotImplementedError
     else:
@@ -107,12 +100,18 @@ def build_mapo_losses(policy, batch_tensors):
                 policy.config["model_loss"]
             )
         )
-    policy.critic_loss = _build_critic_loss(policy, batch_tensors)
-    policy.actor_loss = _build_actor_loss(policy, batch_tensors)
-    policy.loss_stats["dynamics_loss"] = policy.dynamics_loss
-    policy.loss_stats["critic_loss"] = policy.critic_loss
-    policy.loss_stats["actor_loss"] = policy.actor_loss
-    return policy.actor_loss + policy.critic_loss + policy.dynamics_loss
+    critic_loss, critic_stats = _build_critic_loss(
+        batch_tensors, policy.model, policy.action_space, policy.config
+    )
+    actor_loss = _build_actor_loss(batch_tensors, policy.model, policy.config)
+    policy.loss_stats.update(critic_stats)
+    policy.loss_stats["dynamics_loss"] = dynamics_loss
+    policy.loss_stats["critic_loss"] = critic_loss
+    policy.loss_stats["actor_loss"] = actor_loss
+    policy.mapo_losses = AgentComponents(
+        dynamics=dynamics_loss, critic=critic_loss, actor=actor_loss
+    )
+    return dynamics_loss + critic_loss + actor_loss
 
 
 def get_default_config():
@@ -144,28 +143,29 @@ def extra_loss_fetches(policy, _):
     return policy.loss_stats
 
 
-def apply_gradients_with_delays(policy, *_):
+def apply_gradients_with_delays(policy, optimizer, grads_and_vars):
     """
-    Update actor, critic and dynamics models with different frequencies.
+    Update actor and critic models with different frequencies.
 
-    Dynamics model is always updated. Actor and critic models can have different
-    update frequencies. Updates target networks along with actor.
+    For policy gradient, update policy net one time v.s. update critic net
+    `policy_delay` time(s). Also use `policy_delay` for target networks update.
     """
-    # pylint: disable=protected-access
+    # pylint: disable=unused-argument
+    dynamics_grads_and_vars, critic_grads_and_vars, actor_grads_and_vars = (
+        policy.all_grads_and_vars.dynamics,
+        policy.all_grads_and_vars.critic,
+        policy.all_grads_and_vars.actor,
+    )
     with tf.control_dependencies([policy.global_step.assign_add(1)]):
         # Dynamics updates
-        dynamics_op = policy._dynamics_optimizer.apply_gradients(
-            policy._dynamics_grads_and_vars
-        )
+        dynamics_op = optimizer.dynamics.apply_gradients(dynamics_grads_and_vars)
         # Critic updates
         should_apply_critic_opt = tf.equal(
             tf.math.mod(policy.global_step, policy.config["critic_delay"]), 0
         )
 
         def make_critic_apply_op():
-            return policy._critic_optimizer.apply_gradients(
-                policy._critic_grads_and_vars
-            )
+            return optimizer.critic.apply_gradients(critic_grads_and_vars)
 
         with tf.control_dependencies([dynamics_op]):
             critic_op = tf.cond(
@@ -177,7 +177,7 @@ def apply_gradients_with_delays(policy, *_):
         )
 
         def make_actor_apply_op():
-            return policy._actor_optimizer.apply_gradients(policy._actor_grads_and_vars)
+            return optimizer.actor.apply_gradients(actor_grads_and_vars)
 
         with tf.control_dependencies([critic_op]):
             actor_op = tf.cond(

--- a/mapo/agents/mapo/tests/test_delayed_updates.py
+++ b/mapo/agents/mapo/tests/test_delayed_updates.py
@@ -32,8 +32,8 @@ def test_optimizer_global_step_update():
 
     sess = policy.get_session()
     assert sess.run(policy.global_step) == 10
-    assert sess.run(policy._actor_optimizer.iterations) == 5
-    assert sess.run(policy._critic_optimizer.iterations) == 10
+    assert sess.run(policy._optimizer.actor.iterations) == 5
+    assert sess.run(policy._optimizer.critic.iterations) == 10
 
 
 def test_actor_update_frequency():

--- a/mapo/agents/mapo/tests/test_exploration_state.py
+++ b/mapo/agents/mapo/tests/test_exploration_state.py
@@ -38,7 +38,7 @@ def test_pure_exploration():
     def rvs(size=1):
         return np.squeeze(policy.compute_actions(obs.repeat(size, axis=0), [])[0])
 
-    _, p_value = stats.kstest(rvs, cdf, N=4000)
+    _, p_value = stats.kstest(rvs, cdf, N=10000)
     assert p_value >= 0.05
 
 

--- a/mapo/agents/mapo/tests/test_model.py
+++ b/mapo/agents/mapo/tests/test_model.py
@@ -1,0 +1,194 @@
+# pylint: disable=missing-docstring, redefined-outer-name
+import pytest
+from gym.spaces import Box
+import numpy as np
+import tensorflow as tf
+
+from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.models.catalog import ModelCatalog
+
+from mapo.agents.mapo.mapo_model import MAPOModel
+
+
+def get_spaces():
+    return (
+        Box(-np.inf, np.inf, shape=(2,), dtype=np.float32),
+        Box(-1.0, 1.0, shape=(2,), dtype=np.float32),
+    )
+
+
+def get_models():
+    obs_space, action_space = get_spaces()
+    model_config = {
+        "custom_options": {
+            "actor": {"activation": "relu", "layers": [32, 32]},
+            "critic": {"activation": "relu", "layers": [32, 32]},
+            "dynamics": {"activation": "relu", "layers": [32, 32]},
+        }
+    }
+    models = [
+        MAPOModel(
+            obs_space,
+            action_space,
+            1,
+            model_config,
+            "test_model",
+            target_networks=False,
+            twin_q=False,
+        ),
+        MAPOModel(
+            obs_space,
+            action_space,
+            1,
+            model_config,
+            "test_model",
+            target_networks=True,
+            twin_q=False,
+        ),
+        MAPOModel(
+            obs_space,
+            action_space,
+            1,
+            model_config,
+            "test_model",
+            target_networks=False,
+            twin_q=True,
+        ),
+        MAPOModel(
+            obs_space,
+            action_space,
+            1,
+            model_config,
+            "test_model",
+            target_networks=True,
+            twin_q=True,
+        ),
+    ]
+    return models
+
+
+def get_models_with_targets():
+    return get_models()[1:4:2]
+
+
+@pytest.fixture
+def input_dict():
+    obs_space, action_space = get_spaces()
+    obs = tf.compat.v1.placeholder(
+        tf.float32, shape=[None] + list(obs_space.shape), name="observation"
+    )
+    prev_actions = ModelCatalog.get_action_placeholder(action_space)
+    prev_rewards = tf.compat.v1.placeholder(tf.float32, [None], name="prev_reward")
+
+    input_dict = {
+        SampleBatch.CUR_OBS: obs,
+        SampleBatch.PREV_ACTIONS: prev_actions,
+        SampleBatch.PREV_REWARDS: prev_rewards,
+        "is_training": tf.compat.v1.placeholder_with_default(False, ()),
+    }
+    return input_dict
+
+
+@pytest.fixture
+def obs_ph():
+    obs_space, _ = get_spaces()
+    return tf.compat.v1.placeholder(
+        tf.float32, shape=[None] + list(obs_space.shape), name="observation"
+    )
+
+
+@pytest.fixture
+def action_ph():
+    _, action_space = get_spaces()
+    return ModelCatalog.get_action_placeholder(action_space)
+
+
+@pytest.mark.parametrize("model", get_models())
+def test_variables_are_created_on_init(model):
+    assert model.variables()
+
+
+@pytest.mark.parametrize("model", get_models())
+def test_component_variables_are_in_all_variables(model):
+    all_variables = set(model.variables())
+    actor_vars = set(model.actor_variables)
+    critic_vars = set(model.critic_variables)
+    dynamics_vars = set(model.dynamics_variables)
+    assert actor_vars and actor_vars.issubset(all_variables)
+    assert critic_vars and critic_vars.issubset(all_variables)
+    assert dynamics_vars and dynamics_vars.issubset(all_variables)
+
+
+@pytest.mark.parametrize("model", get_models())
+def test_output_is_flattened_obs(model, input_dict):
+    model_out, _ = model(input_dict, [], None)
+    assert model_out.shape[1:] == model.obs_space.shape
+
+
+@pytest.mark.parametrize("model", get_models())
+def test_compute_action(model, obs_ph, action_ph):
+    actions = model.compute_actions(obs_ph)
+    assert actions.shape[1:] == action_ph.shape[1:]
+
+    all_grads = tf.gradients(tf.reduce_sum(actions), model.variables())
+    filtered_all_vars = [
+        var for grad, var in zip(all_grads, model.variables()) if grad is not None
+    ]
+    actor_grads = tf.gradients(tf.reduce_sum(actions), model.actor_variables)
+    filtered_actor_vars = [
+        var for grad, var in zip(actor_grads, model.actor_variables) if grad is not None
+    ]
+    assert set(filtered_all_vars) == set(filtered_actor_vars)
+
+
+@pytest.mark.parametrize("model", get_models())
+def test_compute_q_values(model, obs_ph, action_ph):
+    values = model.compute_q_values(obs_ph, action_ph)
+    assert values.shape[1:] == (1,)
+
+    all_grads = tf.gradients(tf.reduce_sum(values), model.variables())
+    filtered_all_vars = [
+        var for grad, var in zip(all_grads, model.variables()) if grad is not None
+    ]
+    critic_grads = tf.gradients(tf.reduce_sum(values), model.critic_variables)
+    filtered_critic_vars = [
+        var
+        for grad, var in zip(critic_grads, model.critic_variables)
+        if grad is not None
+    ]
+    assert set(filtered_all_vars) == set(filtered_critic_vars)
+
+
+@pytest.mark.parametrize("model", get_models())
+def test_sample_next_states(model, obs_ph, action_ph):
+    states = model.sample_next_states(obs_ph, action_ph)
+    assert states.shape[1:] == obs_ph.shape[1:]
+
+    all_grads = tf.gradients(tf.reduce_sum(states), model.variables())
+    filtered_all_vars = [
+        var for grad, var in zip(all_grads, model.variables()) if grad is not None
+    ]
+    dynamics_grads = tf.gradients(tf.reduce_sum(states), model.dynamics_variables)
+    filtered_dynamics_vars = [
+        var
+        for grad, var in zip(dynamics_grads, model.dynamics_variables)
+        if grad is not None
+    ]
+    assert set(filtered_all_vars) == set(filtered_dynamics_vars)
+
+
+@pytest.mark.parametrize("model", get_models_with_targets())
+def test_uses_target_models(model, obs_ph, action_ph):
+    actions = model.compute_actions(obs_ph, target=True)
+    assert actions.shape[1:] == action_ph.shape[1:]
+    assert all(
+        grad is None
+        for grad in tf.gradients(tf.reduce_sum(actions), model.actor_variables)
+    )
+
+    values = model.compute_q_values(obs_ph, action_ph, target=True)
+    assert values.shape[1:] == (1,)
+    assert all(
+        grad is None
+        for grad in tf.gradients(tf.reduce_sum(values), model.critic_variables)
+    )

--- a/mapo/agents/td3/tests/test_exploration_state.py
+++ b/mapo/agents/td3/tests/test_exploration_state.py
@@ -38,7 +38,7 @@ def test_pure_exploration():
     def rvs(size=1):
         return np.squeeze(policy.compute_actions(obs.repeat(size, axis=0), [])[0])
 
-    _, p_value = stats.kstest(rvs, cdf, N=2000)
+    _, p_value = stats.kstest(rvs, cdf, N=10000)
     assert p_value >= 0.05
 
 

--- a/mapo/envs/registry.py
+++ b/mapo/envs/registry.py
@@ -1,0 +1,18 @@
+"""Registry of custom Gym environment names"""
+
+
+def _import_navigation_v0(_):
+    from mapo.envs import NavigationEnv
+
+    config = {"deceleration_zones": {}}
+    return NavigationEnv(**config)
+
+
+def _import_navigation_v1(_):
+    from mapo.envs import NavigationEnv
+
+    config = {}
+    return NavigationEnv(**config)
+
+
+ENVS = {"Navigation-v0": _import_navigation_v0, "Navigation-v1": _import_navigation_v1}

--- a/mapo/envs/tests/test_navigation.py
+++ b/mapo/envs/tests/test_navigation.py
@@ -9,6 +9,7 @@ import gym
 import tensorflow as tf
 
 import mapo
+from mapo.envs.registry import _import_navigation_v0, _import_navigation_v1
 from mapo.envs.navigation import NavigationEnv, DEFAULT_CONFIG as config
 
 
@@ -16,12 +17,12 @@ mapo.register_all_environments()
 
 
 def get_gym_envs():
-    env0 = gym.make("Navigation-v0")
-    env1 = gym.make("Navigation-v1")
+    env0 = _import_navigation_v0(None)
+    env1 = _import_navigation_v1(None)
     envs = [env0, env1]
     for env in envs:
         env.reset()
-    return [env.env for env in envs]
+    return envs
 
 
 @pytest.mark.parametrize("env", get_gym_envs())

--- a/mapo/envs/tests/test_navigation.py
+++ b/mapo/envs/tests/test_navigation.py
@@ -8,6 +8,7 @@ import numpy as np
 import gym
 
 import mapo
+from mapo.envs.registry import _import_navigation_v0, _import_navigation_v1
 from mapo.envs.navigation import NavigationEnv, DEFAULT_CONFIG as config
 
 
@@ -15,12 +16,12 @@ mapo.register_all_environments()
 
 
 def get_gym_envs():
-    env0 = gym.make("Navigation-v0")
-    env1 = gym.make("Navigation-v1")
+    env0 = _import_navigation_v0(None)
+    env1 = _import_navigation_v1(None)
     envs = [env0, env1]
     for env in envs:
         env.reset()
-    return [env.env for env in envs]
+    return envs
 
 
 @pytest.mark.parametrize("env", get_gym_envs())

--- a/mapo/envs/tests/test_navigation.py
+++ b/mapo/envs/tests/test_navigation.py
@@ -6,6 +6,7 @@ import pytest
 
 import numpy as np
 import gym
+import tensorflow as tf
 
 import mapo
 from mapo.envs.navigation import NavigationEnv, DEFAULT_CONFIG as config
@@ -63,61 +64,68 @@ def test_reset(env):
 
 @pytest.mark.parametrize("env", get_gym_envs())
 def test_sample_noise(env):
-    noise = env._sample_noise()
-    assert noise.shape == env._start.shape
+    with env._graph.as_default():
+        noise = env._sample_noise()
+        assert noise.shape == env._start.shape
 
 
 @pytest.mark.parametrize("env", get_gym_envs())
 def test_distance_to_deceleration_zones(env):
-    if env._deceleration_zones:
-        center = env._deceleration_center
-        distance = env._distance_to_deceleration_zones(center)
-        assert distance.shape == (len(env._deceleration_zones["center"]),)
-        assert distance.shape == (len(env._deceleration_zones["decay"]),)
+    with env._graph.as_default():
+        if env._deceleration_zones:
+            center = env._deceleration_center
+            distance = env._distance_to_deceleration_zones(center)
+            assert distance.shape == (len(env._deceleration_zones["center"]),)
+            assert distance.shape == (len(env._deceleration_zones["decay"]),)
 
 
 @pytest.mark.parametrize("env", get_gym_envs())
 def test_deceleration_factors(env):
-    if env._deceleration_zones:
-        decay = env._deceleration_decay
-        center = env._deceleration_center
-        distance = env._distance_to_deceleration_zones(center)
-        factor = env._deceleration_factors(decay, distance)
-        assert factor.shape == (len(env._deceleration_zones["center"]),)
-        assert factor.shape == (len(env._deceleration_zones["decay"]),)
+    with env._graph.as_default():
+        if env._deceleration_zones:
+            decay = env._deceleration_decay
+            center = env._deceleration_center
+            distance = env._distance_to_deceleration_zones(center)
+            factor = env._deceleration_factors(decay, distance)
+            assert factor.shape == (len(env._deceleration_zones["center"]),)
+            assert factor.shape == (len(env._deceleration_zones["decay"]),)
 
 
 @pytest.mark.parametrize("env", get_gym_envs())
 def test_transition(env):
-    action_low = env.action_space.low
-    action_high = env.action_space.high
+    with env._graph.as_default():
+        action_low = env.action_space.low
+        action_high = env.action_space.high
 
-    state = env.obs
-    action = np.random.uniform(low=action_low, high=action_high)
-    next_states = []
+        state = env.obs
+        action = np.random.uniform(low=action_low, high=action_high)
+        next_states = []
 
-    for _ in range(1000):
-        next_state = env._transition(state, action)
-        next_states.append(next_state)
-        assert next_state.shape == state.shape
+        for _ in range(1000):
+            next_state = env._transition(state, action)
+            next_states.append(next_state)
+            assert next_state.shape == state.shape
 
-    next_states = np.array(next_states, dtype=np.float32)
+        next_states = np.array(next_states, dtype=np.float32)
 
-    if env._deceleration_zones:
-        deceleration = env._deceleration()
-        noises = next_states - state - deceleration * action
-        noise_mean = np.mean(noises, axis=0)
-        noise_cov = np.cov(noises.T)
-        assert np.allclose(noise_mean, env._noise["mean"], atol=1e-1)
-        assert np.allclose(noise_cov, env._noise["cov"], atol=1e-1)
+        if env._deceleration_zones:
+            with tf.Session(graph=env._graph) as sess:
+                feed_dict = {env._state_placeholder: state}
+                deceleration = sess.run(env._deceleration(), feed_dict=feed_dict)
+            noises = next_states - state - deceleration * action
+            noise_mean = np.mean(noises, axis=0)
+            noise_cov = np.cov(noises.T)
+            assert np.allclose(noise_mean, env._noise["mean"], atol=1e-1)
+            assert np.allclose(noise_cov, env._noise["cov"], atol=1e-1)
 
 
 @pytest.mark.parametrize("env", get_gym_envs())
 def test_reward(env):
-    reward = env._reward(env._end)
-    assert np.allclose(reward, 0.0)
-    reward = env._reward(env._start)
-    assert np.allclose(reward, -np.sqrt(2 * 20 ** 2))
+    with env._graph.as_default():
+        reward = env._reward(env._end)
+        assert np.allclose(reward, 0.0)
+        reward = env._reward(env._start)
+        assert np.allclose(reward, -np.sqrt(2 * 20 ** 2))
 
 
 @pytest.mark.parametrize("env", get_gym_envs())

--- a/mapo/models/__init__.py
+++ b/mapo/models/__init__.py
@@ -1,1 +1,4 @@
 """Collection of keras.Model factories."""
+from mapo.models.misc import obs_input, action_input
+
+__all__ = ["obs_input", "action_input"]

--- a/mapo/models/dynamics/tests/test_gaussian.py
+++ b/mapo/models/dynamics/tests/test_gaussian.py
@@ -168,6 +168,14 @@ def test_gaussian_sample(model, state, action):
 
 
 @pytest.mark.parametrize("model", get_models())
+def test_gaussian_sample_propagates_gradients(model, state, action):
+    sample_shape = (10,)
+    next_states = model.sample(state, action, shape=sample_shape)
+    grads = tf.gradients(tf.reduce_sum(next_states), model.variables)
+    assert all(grad is not None for grad in grads)
+
+
+@pytest.mark.parametrize("model", get_models())
 def test_gaussian_log_prob(model, state, action, batch_shape):
     next_state = model.sample(state, action)
     log_prob = model.log_prob(state, action, next_state)

--- a/mapo/models/fcnet.py
+++ b/mapo/models/fcnet.py
@@ -2,25 +2,30 @@
 from tensorflow import keras
 
 DEFAULT_CONFIG = {
+    "layers": (400, 300),
     "activation": "relu",
-    "layers": [400, 300],
     "layer_normalization": False,
 }
 
 
-def build_fcnet(input_shape, config=None):
-    """Construct a fully connected Keras model on inputs."""
-    config = config or {}
+def build_fcnet(config):
+    """Construct a fully connected Keras model.
+
+    Variables are lazily initialized.
+
+    Return:
+        model(keras.Sequential): a fully connected network
+    """
     config = {**DEFAULT_CONFIG, **config}
     activation = config["activation"]
     layer_norm = config["layer_normalization"]
 
-    inputs = output = keras.Input(shape=input_shape)
+    model = keras.Sequential()
     for units in config["layers"]:
         if layer_norm:
-            output = keras.layers.Dense(units=units)(output)
-            output = keras.layers.LayerNormalization(output)
-            output = keras.activations.get(activation)(output)
+            model.add(keras.layers.Dense(units=units))
+            model.add(keras.layers.LayerNormalization())
+            model.add(keras.activations.get(activation))
         else:
-            output = keras.layers.Dense(units=units, activation=activation)(output)
-    return keras.Model(inputs=inputs, outputs=output)
+            model.add(keras.layers.Dense(units=units, activation=activation))
+    return model

--- a/mapo/models/misc.py
+++ b/mapo/models/misc.py
@@ -1,0 +1,13 @@
+"""Model construction utilies."""
+
+from tensorflow import keras
+
+
+def obs_input(obs_space):
+    """Create a keras.Input suitable to receive observations from the obs_space."""
+    return keras.Input(shape=obs_space.shape)
+
+
+def action_input(action_space):
+    """Create a keras.Input suitable to receive actions from the action_space."""
+    return keras.Input(shape=action_space.shape)

--- a/mapo/models/policy.py
+++ b/mapo/models/policy.py
@@ -1,5 +1,6 @@
 """Utilities for constructing policy approximators."""
 from tensorflow import keras
+from mapo.models import obs_input
 from mapo.models.fcnet import build_fcnet
 from mapo.models.layers import ActionSquashingLayer
 
@@ -9,10 +10,11 @@ def build_deterministic_policy(obs_space, action_space, config=None):
     Contruct deterministic policy keras model.
 
     Assumes both obs_space and action_space are gym.spaces.Box instances.
+    Model is called on placeholder inputs so variables are created.
     """
-    policy_input = keras.Input(shape=obs_space.shape)
-
-    policy_out = build_fcnet(policy_input.shape, config=config)(policy_input)
+    config = config or {}
+    obs = obs_input(obs_space)
+    policy_out = build_fcnet(config)(obs)
     policy_out = keras.layers.Dense(units=action_space.shape[0])(policy_out)
-    policy_out = ActionSquashingLayer(action_space)(policy_out)
-    return keras.Model(inputs=policy_input, outputs=policy_out)
+    actions = ActionSquashingLayer(action_space)(policy_out)
+    return keras.Model(inputs=obs, outputs=actions)

--- a/mapo/models/q_function.py
+++ b/mapo/models/q_function.py
@@ -1,5 +1,6 @@
 """Utilities for constructing Q function approximators."""
 from tensorflow import keras
+from mapo.models import obs_input, action_input
 from mapo.models.fcnet import build_fcnet
 
 
@@ -8,11 +9,12 @@ def build_continuous_q_function(obs_space, action_space, config=None):
     Construct continuous Q function keras model.
 
     Assumes both obs_space and action_space are gym.spaces.Box instances.
+    Model is called on placeholder inputs so variables are created.
     """
-    obs_input = keras.Input(shape=obs_space.shape)
-    action_input = keras.Input(shape=action_space.shape)
-    output = keras.layers.Concatenate(axis=-1)([obs_input, action_input])
-
-    output = build_fcnet(output.shape, config=config)(output)
-    output = keras.layers.Dense(units=1, activation=None)(output)
-    return keras.Model(inputs=[obs_input, action_input], outputs=output)
+    config = config or {}
+    obs = obs_input(obs_space)
+    actions = action_input(action_space)
+    output = keras.layers.Concatenate(axis=-1)([obs, actions])
+    output = build_fcnet(config)(output)
+    values = keras.layers.Dense(units=1, activation=None)(output)
+    return keras.Model(inputs=[obs, actions], outputs=values)

--- a/mapo/models/tests/test_policy.py
+++ b/mapo/models/tests/test_policy.py
@@ -1,27 +1,14 @@
 """Tests for policy keras model."""
 # pylint: disable=missing-docstring
 import tensorflow as tf
-from tensorflow import keras
 from mapo.tests.mock_env import MockEnv
 from mapo.models.policy import build_deterministic_policy
-from mapo.models.layers import ActionSquashingLayer
 
 
-def test_policy_output_has_consitent_shape():
+def test_policy_output_has_consistent_shape():
     env = MockEnv()
     ob_space, ac_space = env.observation_space, env.action_space
     policy_model = build_deterministic_policy(ob_space, ac_space)
     obs = tf.placeholder(dtype=ob_space.dtype, shape=(None,) + ob_space.shape)
     output = policy_model(obs)
     assert output.shape.as_list() == tf.TensorShape((None,) + ac_space.shape).as_list()
-
-
-def test_policy_model_is_serializable():
-    env = MockEnv()
-    ob_space, ac_space = env.observation_space, env.action_space
-    policy_model = build_deterministic_policy(ob_space, ac_space)
-    policy_config = policy_model.get_config()
-    keras.Model.from_config(
-        policy_config,
-        custom_objects={ActionSquashingLayer.__name__: ActionSquashingLayer},
-    )

--- a/mapo/models/tests/test_q_function.py
+++ b/mapo/models/tests/test_q_function.py
@@ -1,7 +1,6 @@
 """Tests for Q keras model."""
 # pylint: disable=missing-docstring
 import tensorflow as tf
-from tensorflow import keras
 from mapo.tests.mock_env import MockEnv
 from mapo.models.q_function import build_continuous_q_function
 
@@ -14,11 +13,3 @@ def test_q_function_output_has_consistent_shape():
     actions = tf.placeholder(dtype=ac_space.dtype, shape=(None,) + ac_space.shape)
     output = q_model([obs, actions])
     assert output.shape.as_list() == tf.TensorShape((None, 1)).as_list()
-
-
-def test_q_function_model_is_serializable():
-    env = MockEnv()
-    ob_space, ac_space = env.observation_space, env.action_space
-    q_model = build_continuous_q_function(ob_space, ac_space)
-    q_config = q_model.get_config()
-    keras.Model.from_config(q_config)

--- a/scripts/actor.json
+++ b/scripts/actor.json
@@ -1,0 +1,7 @@
+{
+  "activation": "relu",
+  "layers": [
+    64,
+    64
+  ]
+}

--- a/scripts/critic.json
+++ b/scripts/critic.json
@@ -1,0 +1,7 @@
+{
+  "activation": "relu",
+  "layers": [
+    128,
+    128
+  ]
+}

--- a/scripts/dynamics.json
+++ b/scripts/dynamics.json
@@ -1,0 +1,4 @@
+{
+  "activation": "relu",
+  "layers": []
+}

--- a/scripts/mapo
+++ b/scripts/mapo
@@ -191,7 +191,6 @@ def run(args):
         # },
         config={
             "env": tune.grid_search(args.env),
-            "num_workers": args.num_workers,
             "model": {
                 "custom_model": "mapo_model",
                 "custom_options": {
@@ -200,7 +199,16 @@ def run(args):
                     "dynamics": args.config_dynamics_net,
                 },
             },
+            "num_workers": args.num_workers,
+            "sample_batch_size": args.sample_batch_size,
+            "train_batch_size": args.train_batch_size,
+            "policy_delay": args.policy_delay,
+            "critic_delay": args.critic_delay,
+            "actor_lr": args.actor_lr,
+            "critic_lr": args.critic_lr,
+            "dynamics_lr": args.dynamics_lr,
         },
+        num_samples=args.num_samples,
     )
 
     return analysis

--- a/scripts/mapo
+++ b/scripts/mapo
@@ -145,7 +145,7 @@ def parse_args():
         help="The number of GPUs to allocate to the driver (default=0.0).",
     )
     resources_args_group.add_argument(
-        "--num-cpus",
+        "--num-cpus-for-driver",
         type=int,
         default=1,
         help="The number of CPUs to allocate to the driver (default=1).",
@@ -186,7 +186,7 @@ def run(args):
         verbose=args.verbose,
         stop={"timesteps_total": args.timesteps_total},
         # resources_per_trial={
-        #     "cpu": args.num_cpus,
+        #     "cpu": args.num_cpus_for_driver,
         #     "gpu": args.num_gpus,
         # },
         config={

--- a/scripts/mapo
+++ b/scripts/mapo
@@ -1,0 +1,231 @@
+#! /usr/bin/env python3
+
+"""MAPO running script."""
+
+# pylint: disable=import-self, no-name-in-module
+
+import argparse
+import json
+import ray
+from ray import tune
+from mapo import register_all_agents, register_all_environments
+from mapo.version import __version__
+
+
+def read_config_json(filepath):
+    """Load JSON object from file."""
+    with open(filepath, "r") as file:
+        return json.loads(file.read())
+
+
+def parse_args():
+    """Parse command-line arguments."""
+    description = "Model-Aware Policy Optimization ({})".format(__version__)
+    usage = (
+        "%(prog)s --run {MAPO,OffMAPO} [--model-learning {MLE,PGA}]"
+        " --env ENV [ENV ...] [CONFIG-OPTIONS]"
+    )
+
+    parser = argparse.ArgumentParser(usage=usage, description=description)
+
+    parser.add_argument(
+        "--run",
+        type=str,
+        choices=["MAPO", "OffMAPO"],
+        required=True,
+        help="The algorithm or model to train.",
+    )
+    parser.add_argument(
+        "--model-learning",
+        type=str,
+        choices=["mle", "pg-aware"],
+        default="pg-aware",
+        help="The loss function used for learning the dynamics model. "
+        "(default=pg-aware)",
+    )
+    parser.add_argument(
+        "--env",
+        type=str,
+        nargs="+",
+        default=[],
+        required=True,
+        help="The gym environment to use.",
+    )
+    parser.add_argument(
+        "--verbose",
+        type=int,
+        choices=[0, 1, 2],
+        default=2,
+        help="0, 1, or 2. Verbosity mode. 0 = silent, "
+        "1 = only status updates, 2 = status and trial results "
+        "(default=2)",
+    )
+
+    model_args_group = parser.add_argument_group(">> Model")
+    model_args_group.add_argument(
+        "--config-actor-net",
+        type=read_config_json,
+        help="The actor network configuration JSON file.",
+    )
+    model_args_group.add_argument(
+        "--config-critic-net",
+        type=read_config_json,
+        help="The critic network configuration JSON file.",
+    )
+    model_args_group.add_argument(
+        "--config-dynamics-net",
+        type=read_config_json,
+        help="The dynamics network configuration JSON file.",
+    )
+
+    optimizers_args_group = parser.add_argument_group(">> Optimization")
+    optimizers_args_group.add_argument(
+        "--actor-lr",
+        type=float,
+        default=1e-3,
+        help="The learning rate for the actor (policy) optimizer " "(defaul=1e-3).",
+    )
+    optimizers_args_group.add_argument(
+        "--critic-lr",
+        type=float,
+        default=1e-3,
+        help="The learning rate for the critic (Q-function) optimizer "
+        "(defaul=1e-3).",
+    )
+    optimizers_args_group.add_argument(
+        "--dynamics-lr",
+        type=float,
+        default=1e-3,
+        help="The learning rate for the dynamics optimizer (defaul=1e-3).",
+    )
+    optimizers_args_group.add_argument(
+        "--policy-delay",
+        type=int,
+        default=2,
+        help="The number of traing steps before updating the policy " "(default=2).",
+    )
+    optimizers_args_group.add_argument(
+        "--critic-delay",
+        type=int,
+        default=1,
+        help="The number of traing steps before updating the critic " "(default=2).",
+    )
+
+    exec_args_group = parser.add_argument_group(">> Execution")
+    exec_args_group.add_argument(
+        "--timesteps-total",
+        type=int,
+        default=1000,
+        help="The total number of timesteps (default=1000).",
+    )
+    exec_args_group.add_argument(
+        "--sample-batch-size",
+        type=int,
+        default=10,
+        help="The size of the batch collected by workers (default=10).",
+    )
+    exec_args_group.add_argument(
+        "--train-batch-size",
+        type=int,
+        default=100,
+        help="The size of the batch for training (default=100).",
+    )
+
+    resources_args_group = parser.add_argument_group(">> Resources")
+    resources_args_group.add_argument(
+        "--num-workers",
+        type=int,
+        default=0,
+        help="The number of actors used for parallelism (default=0).",
+    )
+    resources_args_group.add_argument(
+        "--num-gpus",
+        type=float,
+        default=0.0,
+        help="The number of GPUs to allocate to the driver (default=0.0).",
+    )
+    resources_args_group.add_argument(
+        "--num-cpus",
+        type=int,
+        default=1,
+        help="The number of CPUs to allocate to the driver (default=1).",
+    )
+
+    exp_args_group = parser.add_argument_group(">> Experiment")
+    exp_args_group.add_argument(
+        "--num-samples",
+        type=int,
+        default=1,
+        help="The number of times to sample from the hyperparameter space "
+        "(default=1).",
+    )
+    exp_args_group.add_argument("--name", type=str, help="The name of the experiment.")
+
+    return parser.parse_args()
+
+
+def init():
+    """Initialize ray framework."""
+    ray.init()
+
+
+def register():
+    """Register all agents and custom environtments."""
+    register_all_agents()
+    register_all_environments()
+
+
+def run(args):
+    """Run experiments with configuration given by command-line arguments."""
+    trainer = args.run
+    experiment = args.name
+
+    analysis = tune.run(
+        trainer,
+        name=experiment,
+        verbose=args.verbose,
+        stop={"timesteps_total": args.timesteps_total},
+        # resources_per_trial={
+        #     "cpu": args.num_cpus,
+        #     "gpu": args.num_gpus,
+        # },
+        config={
+            "env": tune.grid_search(args.env),
+            "num_workers": args.num_workers,
+            "model": {
+                "custom_model": "mapo_model",
+                "custom_options": {
+                    "actor": args.config_actor_net,
+                    "critic": args.config_critic_net,
+                    "dynamics": args.config_dynamics_net,
+                },
+            },
+        },
+    )
+
+    return analysis
+
+
+def report(analysis):
+    """Report analysis for best configuraion in experiments."""
+    best_config = analysis.get_best_config("episode_reward_mean", mode="max")
+    best_logdir = analysis.get_best_logdir("episode_reward_mean", mode="max")
+
+    print(">> Best configuration:")
+    print(json.dumps(best_config, indent=2, sort_keys=True))
+    print()
+
+    print("tensorboard --logdir={}".format(best_logdir))
+    print()
+
+
+if __name__ == "__main__":
+    # pylint: disable=invalid-name
+
+    arguments = parse_args()
+
+    init()
+    register()
+
+    results = run(arguments)
+    report(results)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     keywords=["reinforcement-learning", "model-based", "rllib", "tensorflow"],
     url="",
     packages=find_packages(),
-    scripts=[],
+    scripts=["scripts/mapo"],
     install_requires=[
         "gym",
         "ray[rllib]==0.7.3",


### PR DESCRIPTION
Scaffold script for calling mapo trainers with configuration given by command-line arguments. Needs some work to make experiments more practical by making better use of [Tune](https://ray.readthedocs.io/en/latest/tune-usage.html#training-features), but it's a start.

Overall, the main goal here is to make sure all components (custom envs, trainers, policies) are  smoothly integrated (and also for me to gain experience with rllib training outputs, metrics reported, ...)