### PR TITLE
feat: use observed samples when branching factor is 0

### DIFF
--- a/mapo/agents/mapo/losses.py
+++ b/mapo/agents/mapo/losses.py
@@ -109,17 +109,28 @@ def actor_model_aware_loss(batch_tensors, model, env, config):
     gamma = config["gamma"]
     n_samples = config["branching_factor"]
     actions = model.compute_actions(obs)
-    if config["use_true_dynamics"]:
-        sampled_next_state, next_state_log_prob = env._transition_fn(
-            tf.broadcast_to(obs, tf.concat([(n_samples,), tf.shape(obs)], axis=0)),
-            tf.broadcast_to(
-                actions, tf.concat([(n_samples,), tf.shape(actions)], axis=0)
-            ),
-        )
+    if n_samples == 0:
+        sampled_next_state = tf.expand_dims(batch_tensors[SampleBatch.NEXT_OBS], 0)
+        if config["use_true_dynamics"]:
+            next_state_log_prob = env._transition_log_prob_fn(
+                obs, actions, sampled_next_state
+            )
+        else:
+            next_state_log_prob = model.compute_states_log_prob(
+                obs, actions, sampled_next_state
+            )
     else:
-        sampled_next_state, next_state_log_prob = model.compute_log_prob_sampled(
-            obs, actions, (n_samples,)
-        )
+        if config["use_true_dynamics"]:
+            sampled_next_state, next_state_log_prob = env._transition_fn(
+                tf.broadcast_to(obs, tf.concat([(n_samples,), tf.shape(obs)], axis=0)),
+                tf.broadcast_to(
+                    actions, tf.concat([(n_samples,), tf.shape(actions)], axis=0)
+                ),
+            )
+        else:
+            sampled_next_state, next_state_log_prob = model.compute_log_prob_sampled(
+                obs, actions, (n_samples,)
+            )
     next_state_value = tf.stop_gradient(
         tf.squeeze(model.compute_state_values(sampled_next_state))
     )

--- a/mapo/agents/mapo/mapo.py
+++ b/mapo/agents/mapo/mapo.py
@@ -15,6 +15,7 @@ DEFAULT_CONFIG = with_common_config(
     {
         # === MAPO ===
         # How many samples to draw from the dynamics model
+        # If this is set to 0, use the next state observed from the environment
         "branching_factor": 1,
         # Whether to use the env's dynamics to calculate the actor loss
         "use_true_dynamics": False,


### PR DESCRIPTION
Use the next state from each observed transition `(s,a,r,s)` in `losses.actor_model_aware_loss` if `config["branching_factor"]` is set to 0.

I've run the following command to check that everything runs as intended
```shell
mapo --run MAPO --env Navigation-v0  --branching-factor 0 --use-true-dynamics --config-actor-net actor-1024-relu.json --config-critic-net critic-1024-relu.json --actor-lr 1e-4 --critic-lr 1e-4 --sample-batch-size 1 --train-batch-size 2048 --num-samples 4 --name nav0-mapo-true-dynamics-fcnet-1024
```

Closes #74 