### PR TITLE
fix: maximize the actor objective

### DIFF
--- a/mapo/agents/mapo/losses.py
+++ b/mapo/agents/mapo/losses.py
@@ -124,7 +124,7 @@ def actor_model_aware_loss(batch_tensors, model, env, config):
         tf.squeeze(model.compute_state_values(sampled_next_state))
     )
     reward = tf.reduce_mean(env._reward_fn(obs, actions, sampled_next_state), axis=0)
-    model_aware_policy_loss = tf.reduce_mean(
+    model_aware_policy_objective = tf.reduce_mean(
         reward + gamma * tf.reduce_mean(next_state_log_prob * next_state_value, axis=0)
     )
-    return model_aware_policy_loss
+    return -model_aware_policy_objective


### PR DESCRIPTION
Running 
```bash
mapo --run MAPO --env Navigation-v0 --use-true-dynamics --config-actor-net actor-1024-relu.json --config-critic-net critic-1024-relu.json --actor-lr 1e-4 --critic-lr 1e-4 --sample-batch-size 1 --train-batch-size 2048 --num-samples 5 --name nav0-mapo-true-dynamics-fcnet-1024
```
successfully shows increasing episode returns.

Closes #81 