### PR TITLE
Feature: add defaults for debugging with episode traces

### DIFF
--- a/mapo/agents/mapo/mapo.py
+++ b/mapo/agents/mapo/mapo.py
@@ -54,6 +54,17 @@ DEFAULT_CONFIG = with_common_config(
         # === Resources ===
         # Number of actors used for parallelism
         "num_workers": 0,
+        # === Debugging ===
+        # Specify where experiences should be saved:
+        #  - None: don't save any experiences
+        #  - "logdir" to save to the agent log dir
+        #  - a path/URI to save to a custom output directory (e.g., "s3://bucket/")
+        #  - a function that returns a rllib.offline.OutputWriter
+        "output": None,
+        # What sample batch columns to LZ4 compress in the output data.
+        # RLlib's default is ["obs", "new_obs"], which saves space but makes the
+        # output unreadable.
+        "output_compress_columns": [],
     }
 )
 

--- a/scripts/experiments/experiments.sh
+++ b/scripts/experiments/experiments.sh
@@ -1,14 +1,17 @@
-# nav0-baseline-td3-fcnet-1024
-mapo --run OurTD3 --env Navigation-v0 --config-actor-net actor-1024-relu.json --config-critic-net critic-1024-relu.json --actor-lr 1e-4 --critic-lr 1e-4 --sample-batch-size 1 --train-batch-size 2048 --num-samples 5 --name nav0-baseline-td3-fcnet-1024
+# nav0-td3-baseline-fcnet-64
+mapo --run OurTD3 --env Navigation-v0 --config-actor-net fcnet-64-elu.json --config-critic-net fcnet-64-elu.json --actor-lr 1e-4 --critic-lr 1e-4 --train-batch-size 128 --num-samples 5 --actor-delay 2 --timesteps-total 200000 --name nav0-td3-baseline-fcnet-64 --num-cpus-for-driver 2 --num-gpus 1.0 --debug
 
-# nav0-mapo-true-dynamics-fcnet-1024
-mapo --run MAPO --env Navigation-v0 --use-true-dynamics --config-actor-net actor-1024-relu.json --config-critic-net critic-1024-relu.json --actor-lr 1e-4 --critic-lr 1e-4 --sample-batch-size 1 --train-batch-size 2048 --num-samples 5 --name nav0-mapo-true-dynamics-fcnet-1024
+# nav0-mapo-true-dynamics-fcnet-64
+mapo --run MAPO --env Navigation-v0 --use-true-dynamics --config-actor-net fcnet-64-elu.json --config-critic-net fcnet-64-elu.json --actor-lr 1e-4 --critic-lr 1e-4 --train-batch-size 128 --num-samples 5 --timesteps-total 200000 --name nav0-mapo-true-dynamics-fcnet-64 --num-cpus-for-driver 2 --num-gpus 1.0 --debug
 
-# nav0-mapo-mle-fcnet-1024-linear-dynamics
-mapo --run MAPO --env Navigation-v0 --model-loss mle --config-actor-net actor-1024-relu.json --config-critic-net critic-1024-relu.json --config-dynamics-net dynamics-linear-relu.json --actor-lr 1e-4 --critic-lr 1e-4 --dynamics-lr 1e-4 --sample-batch-size 1 --train-batch-size 2048 --num-samples 5 --name nav0-mapo-mle-fcnet-1024-linear-dynamics
+# nav0-mapo-mle-fcnet-64-linear-dynamics
+mapo --run MAPO --env Navigation-v0 --model-loss mle --config-actor-net fcnet-64-elu.json --config-critic-net fcnet-64-elu.json --config-dynamics-net dynamics-linear-relu.json --actor-lr 1e-4 --critic-lr 1e-4 --dynamics-lr 1e-4 --train-batch-size 128 --num-samples 5 --timesteps-total 200000 --name nav0-mapo-mle-fcnet-64-linear-dynamics --num-cpus-for-driver 2 --num-gpus 1.0 --debug
 
-# nav0-mapo-pga-fcnet-1024-linear-dynamics
-mapo --run MAPO --env Navigation-v0 --model-loss pga --config-actor-net actor-1024-relu.json --config-critic-net critic-1024-relu.json --config-dynamics-net dynamics-linear-relu.json --actor-lr 1e-4 --critic-lr 1e-4 --dynamics-lr 1e-4 --sample-batch-size 1 --train-batch-size 2048 --num-samples 5 --name nav0-mapo-pga-fcnet-1024-linear-dynamics
+# nav0-mapo-pga-fcnet-64-linear-dynamics
+mapo --run MAPO --env Navigation-v0 --model-loss pga --config-actor-net fcnet-64-elu.json --config-critic-net fcnet-64-elu.json --config-dynamics-net dynamics-linear-relu.json --actor-lr 1e-4 --critic-lr 1e-4 --dynamics-lr 1e-4 --train-batch-size 128 --num-samples 5 --timesteps-total 200000 --name nav0-mapo-pga-fcnet-64-linear-dynamics --num-cpus-for-driver 2 --num-gpus 1.0 --debug
 
-# nav0-mapo-mle-fcnet-1024
-mapo --run MAPO --env Navigation-v0 --model-loss mle --config-actor-net actor-1024-relu.json --config-critic-net critic-1024-relu.json --config-dynamics-net dynamics-1024-relu.json --actor-lr 1e-4 --critic-lr 1e-4 --dynamics-lr 1e-4 --sample-batch-size 1 --train-batch-size 2048 --num-samples 5 --name nav0-mapo-mle-fcnet-1024
+# nav0-mapo-mle-fcnet-64
+mapo --run MAPO --env Navigation-v0 --model-loss mle --config-actor-net fcnet-64-elu.json --config-critic-net fcnet-64-elu.json --config-dynamics-net fcnet-64-elu.json --actor-lr 1e-4 --critic-lr 1e-4 --dynamics-lr 1e-4 --train-batch-size 128 --num-samples 5 --timesteps-total 200000 --name nav0-mapo-mle-fcnet-64 --num-cpus-for-driver 2 --num-gpus 1.0 --debug
+
+# nav0-mapo-pga-fcnet-64
+mapo --run MAPO --env Navigation-v0 --model-loss pga --config-actor-net fcnet-64-elu.json --config-critic-net fcnet-64-elu.json --config-dynamics-net fcnet-64-elu.json --actor-lr 1e-4 --critic-lr 1e-4 --dynamics-lr 1e-4 --train-batch-size 128 --num-samples 5 --timesteps-total 200000 --name nav0-mapo-pga-fcnet-1024 --num-cpus-for-driver 2 --num-gpus 1.0 --debug

--- a/scripts/mapo
+++ b/scripts/mapo
@@ -283,7 +283,7 @@ def make_config(args):
         "actor_delay": args.actor_delay,
     }
     if args.run == "MAPO":
-        optimization_config["num_sgd_iter"] = args.num_sgd_iter
+        optimization_config["optimizer"] = {"num_sgd_iter": args.num_sgd_iter}
 
     if args.run in ["MAPO", "OffMAPO"]:
         optimization_config["critic_delay"] = args.critic_delay

--- a/scripts/mapo
+++ b/scripts/mapo
@@ -49,6 +49,12 @@ def parse_args():
         "1 = only status updates, 2 = status and trial results "
         "(default=2)",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Debugging flag (default=False).",
+    )
 
     mapo_args_group = parser.add_argument_group(">> MAPO")
     mapo_args_group.add_argument(
@@ -314,6 +320,9 @@ def make_config(args):
         eval_config["evaluation_interval"] = args.evaluation_interval
         eval_config["evaluation_num_episodes"] = args.evaluation_num_episodes
 
+    # === Debugging ===
+    debugging_config = {"output": "logdir" if args.debug else None}
+
     # === TF Session ===
     tf_session_config = {"tf_session_args": {"log_device_placement": True}}
 
@@ -326,6 +335,7 @@ def make_config(args):
         **execution_config,
         **resources_config,
         **eval_config,
+        **debugging_config,
         **tf_session_config,
     }
 


### PR DESCRIPTION
I tested it by setting `"ouput": "logdir"`. This saves episode traces under each experimente directory. For example, here's the directory for a `tune` run with several trials:
```zsh
(mapo) ➜  MAPO git:(master) ls data/MAPO/
MAPO_Navigation-v0_0_2019-08-22_07-54-195yfufcxt MAPO_Navigation-v0_5_2019-08-22_07-58-586nfnpp56
MAPO_Navigation-v0_1_2019-08-22_07-54-194tq69afn MAPO_Navigation-v0_6_2019-08-22_07-59-01c8s44kly
MAPO_Navigation-v0_2_2019-08-22_07-54-19o3j1hkew MAPO_Navigation-v0_7_2019-08-22_07-59-04wnhg2apo
MAPO_Navigation-v0_3_2019-08-22_07-54-19qty3cogb experiment_state-2019-08-22_07-54-19.json
MAPO_Navigation-v0_4_2019-08-22_07-58-57iyt0eu_r
```
Under the first directory, we have the following:
```zsh
(mapo) ➜  MAPO git:(master) ls data/MAPO/MAPO_Navigation-v0_0_2019-08-22_07-54-195yfufcxt
checkpoint_20                                            params.pkl
events.out.tfevents.1566471283.Angelos-MacBook-Pro.local progress.csv
output-2019-08-22_07-54-30_worker-0_0.json               result.json
params.json
```
In `output-DATE_worker_X_0.json` we have the episode traces for the corresponding worker. We can check which configuration was running by looking into the `params.json` file in the same directory.

Is that enough for our purposes?