### PR TITLE
fix: check obs type when branching factor is 0

### DIFF
--- a/mapo/agents/mapo/losses.py
+++ b/mapo/agents/mapo/losses.py
@@ -115,7 +115,11 @@ def actor_model_aware_loss(batch_tensors, model, env, config):
     n_samples = config["branching_factor"]
     actions = model.compute_actions(obs)
     if n_samples == 0:
-        sampled_next_state = tf.expand_dims(batch_tensors[SampleBatch.NEXT_OBS], 0)
+        sampled_next_state = batch_tensors[SampleBatch.NEXT_OBS]
+        if isinstance(sampled_next_state, (tuple, list)):
+            sampled_next_state = tuple(tf.expand_dims(x, 0) for x in sampled_next_state)
+        else:
+            sampled_next_state = tf.expand_dims(sampled_next_state, 0)
         if config["use_true_dynamics"]:
             next_state_log_prob = env._transition_log_prob_fn(
                 obs, actions, sampled_next_state

--- a/mapo/tests/agents/mapo/test_losses.py
+++ b/mapo/tests/agents/mapo/test_losses.py
@@ -66,13 +66,8 @@ def twin_q(request):
     return request.param
 
 
-@pytest.fixture(params=[False, True])
-def use_true_dynamics(request):
-    return request.param
-
-
 @pytest.fixture
-def config(model_config, twin_q, smooth_target_policy):
+def config(model_config, smooth_target_policy, twin_q):
     return {
         "gamma": 0.99,
         "kernel": "l2",
@@ -84,6 +79,16 @@ def config(model_config, twin_q, smooth_target_policy):
         "target_noise": 0.2,
         "target_noise_clip": 0.5,
     }
+
+
+@pytest.fixture(params=[False, True])
+def use_true_dynamics(request):
+    return request.param
+
+
+@pytest.fixture(params=[0, 4])
+def branching_factor(request):
+    return request.param
 
 
 @pytest.fixture(params=[True, False])
@@ -210,10 +215,12 @@ def test_actor_dpg_loss(env, config, model_fn, batch_tensors_fn):
 
 
 def test_actor_model_aware_loss(
-    use_true_dynamics, env, config, model_fn, batch_tensors_fn
+    use_true_dynamics, branching_factor, env, config, model_fn, batch_tensors_fn
 ):
+    # pylint: disable=too-many-arguments
     model = model_fn(env, config)
     batch_tensors = batch_tensors_fn(env)
+    config["branching_factor"] = branching_factor
     config["use_true_dynamics"] = use_true_dynamics
     loss = losses.actor_model_aware_loss(batch_tensors, model, env, config)
     variables = model.actor_variables


### PR DESCRIPTION
Turns out the "branching_factor": 0 was breaking: tuple spaces were not properly considered.