### PR TITLE
feat: add critic explained variance statistic

### DIFF
--- a/mapo/agents/mapo/losses.py
+++ b/mapo/agents/mapo/losses.py
@@ -3,6 +3,7 @@ import tensorflow as tf
 from tensorflow import keras
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.evaluation.postprocessing import Postprocessing
+from ray.rllib.utils.explained_variance import explained_variance
 
 from mapo.kernels import KERNELS
 
@@ -92,6 +93,9 @@ def critic_return_loss(batch_tensors, model):
     q_loss_criterion = keras.losses.MeanSquaredError()
     q_pred = tf.squeeze(model.compute_q_values(obs, actions))
     fetches = {
+        "explained_variance": explained_variance(
+            batch_tensors[Postprocessing.ADVANTAGES], q_pred
+        ),
         "q_mean": tf.reduce_mean(q_pred),
         "q_max": tf.reduce_max(q_pred),
         "q_min": tf.reduce_min(q_pred),


### PR DESCRIPTION
Add an additional debugging log that helps us see if the critic is predicting the returns. From Berkeley's 2017 Deep RL Bootcamp:
![Screen Shot 2019-08-24 at 23 59 28](https://user-images.githubusercontent.com/12701614/63644967-3c123e00-c6cb-11e9-8af3-01a336e7bf38.png)
