### PR TITLE
Feature/reparametrize dynamics

### DIFF
--- a/mapo/agents/mapo/mapo.py
+++ b/mapo/agents/mapo/mapo.py
@@ -47,6 +47,9 @@ DEFAULT_CONFIG = with_common_config(
         "actor_optimizer": "Adam",
         "critic_optimizer": "Adam",
         "dynamics_optimizer": "Adam",
+        # Whether to update components using separate "sgd_iter"s for each or
+        # apply "delayed" updates to each.
+        "apply_gradients": "sgd_iter",
         # Number of updates for critic and dynamics for each actor update.
         "critic_sgd_iter": 80,
         "dynamics_sgd_iter": 80,

--- a/mapo/agents/mapo/mapo.py
+++ b/mapo/agents/mapo/mapo.py
@@ -49,7 +49,7 @@ DEFAULT_CONFIG = with_common_config(
         "dynamics_optimizer": "Adam",
         # Whether to update components using separate "sgd_iter"s for each or
         # apply "delayed" updates to each.
-        "apply_gradients": "sgd_iter",
+        "apply_gradients": "delayed",
         # Number of updates for critic and dynamics for each actor update.
         "critic_sgd_iter": 80,
         "dynamics_sgd_iter": 80,

--- a/mapo/agents/mapo/mapo.py
+++ b/mapo/agents/mapo/mapo.py
@@ -25,6 +25,10 @@ DEFAULT_CONFIG = with_common_config(
         "model_loss": "mle",
         # Which kernel metric to compare gradients in dynamics loss
         "kernel": "l2",
+        # Which gradient estimator to use in model-aware dpg
+        # Valid values: "sf" (score function), "pd" (pathwise derivative)
+        # Warning: "pd" is incompatible with a branching factor of 0, for now
+        "madpg_estimator": "sf",
         # === Model ===
         # actor and critic network configuration
         "model": merge_dicts(

--- a/mapo/agents/mapo/mapo_model.py
+++ b/mapo/agents/mapo/mapo_model.py
@@ -146,22 +146,17 @@ class MAPOModel(TFModelV2):  # pylint: disable=abstract-method
         """Compute state values by composing policy and Q networks."""
         return self.compute_q_values(obs, self.compute_actions(obs))
 
-    def compute_state_dist(self, obs, action):
-        """Compute the the dynamics model's conditional distribution of
-        the next state."""
-        return self.models["dynamics"].dist(obs, action)
-
-    def sample_next_states(self, obs, action, shape=()):
-        """Sample the next state from the dynamics model."""
-        return self.models["dynamics"].sample(obs, action, shape=shape)
+    def rsample_next_states(self, obs, action, n_samples=1):
+        """Compute reparameterized next state samples from the dynamics model."""
+        return self.models["dynamics"].sample(obs, action, shape=(n_samples,))
 
     def compute_states_log_prob(self, obs, action, next_obs):
         """Compute the log-likelihood of a transition using the dynamics model."""
         return self.models["dynamics"].log_prob(obs, action, next_obs)
 
-    def compute_log_prob_sampled(self, obs, action, shape=()):
+    def compute_log_prob_sampled(self, obs, action, n_samples=1):
         """Sample the next state and compute its log_prob using the dynamics model."""
-        return self.models["dynamics"].log_prob_sampled(obs, action, shape=shape)
+        return self.models["dynamics"].log_prob_sampled(obs, action, shape=(n_samples,))
 
     def _get_model(self, name, is_target):
         return self.target_models[name] if is_target else self.models[name]

--- a/mapo/tests/agents/mapo/test_delayed_updates.py
+++ b/mapo/tests/agents/mapo/test_delayed_updates.py
@@ -6,7 +6,12 @@ from ray.rllib.evaluation import RolloutWorker
 
 @pytest.fixture
 def policy_config():
-    return lambda env_name: {"actor_delay": 3, "critic_delay": 2, "env": env_name}
+    return lambda env_name: {
+        "actor_delay": 3,
+        "critic_delay": 2,
+        "env": env_name,
+        "apply_gradients": "delayed",
+    }
 
 
 @pytest.fixture

--- a/mapo/tests/agents/mapo/test_model.py
+++ b/mapo/tests/agents/mapo/test_model.py
@@ -170,7 +170,7 @@ def test_compute_q_values(model, obs_ph, action_ph):
 
 def test_rsample_next_states(model, obs_ph, action_ph):
     states = model.rsample_next_states(obs_ph, action_ph)
-    assert states.shape[1:] == obs_ph.shape[1:]
+    assert states.shape[2:] == obs_ph.shape[1:]
 
     all_grads = tf.gradients(tf.reduce_sum(states), model.variables())
     filtered_all_vars = [

--- a/mapo/tests/agents/mapo/test_model.py
+++ b/mapo/tests/agents/mapo/test_model.py
@@ -168,8 +168,8 @@ def test_compute_q_values(model, obs_ph, action_ph):
     assert set(filtered_all_vars) == set(filtered_critic_vars)
 
 
-def test_sample_next_states(model, obs_ph, action_ph):
-    states = model.sample_next_states(obs_ph, action_ph)
+def test_rsample_next_states(model, obs_ph, action_ph):
+    states = model.rsample_next_states(obs_ph, action_ph)
     assert states.shape[1:] == obs_ph.shape[1:]
 
     all_grads = tf.gradients(tf.reduce_sum(states), model.variables())

--- a/mapo/tests/agents/td3/test_delayed_updates.py
+++ b/mapo/tests/agents/td3/test_delayed_updates.py
@@ -9,7 +9,11 @@ from mapo.agents.td3.td3_policy import TD3TFPolicy
 
 @pytest.fixture
 def policy_config():
-    return lambda env_name: {"policy_delay": 3, "env": env_name}
+    return lambda env_name: {
+        "policy_delay": 3,
+        "env": env_name,
+        "apply_gradients": "delayed",
+    }
 
 
 @pytest.fixture


### PR DESCRIPTION
Add pathwise derivative estimator option to Model-Aware DPG loss.

Bonus: add config option to switch between applying gradients with delays or optimizing submodels with separate loops.